### PR TITLE
cappuccino/fetch: initialize imem_err during reset

### DIFF
--- a/rtl/verilog/mor1kx_fetch_cappuccino.v
+++ b/rtl/verilog/mor1kx_fetch_cappuccino.v
@@ -361,8 +361,11 @@ module mor1kx_fetch_cappuccino
    assign ibus_req_o = ibus_access ? ibus_req : ic_ibus_req;
    assign ibus_burst_o = ic_refill & !ic_refill_done;
 
-   always @(posedge clk)
-     imem_err <= ibus_err_i;
+   always @(posedge clk `OR_ASYNC_RST)
+     if (rst)
+       imem_err <= 0;
+     else
+       imem_err <= ibus_err_i;
 
    always @(posedge clk) begin
       ibus_ack <= 0;


### PR DESCRIPTION
Without this, during simulations, ibus_adr_o is undefined
after reset is released. This undefined state can lead
to an undefined state on ibus_err_i and we are stuck in
this state.

Signed-off-by: Franck Jullien franck.jullien@gmail.com
