### PR TITLE
pic: consistent acking for EDGE and LATCHED_LEVEL

### DIFF
--- a/rtl/verilog/mor1kx_pic.v
+++ b/rtl/verilog/mor1kx_pic.v
@@ -69,8 +69,8 @@ module mor1kx_pic
 		  spr_picsr[irqline] <= 0;
 	      // Clear
 		else if (spr_we_i & spr_addr_i==`OR1K_SPR_PICSR_ADDR)
-		  spr_picsr[irqline] <= spr_dat_i[irqline] ? 0 :
-					       spr_picsr[irqline];
+		  spr_picsr[irqline] <= spr_dat_i[irqline] ?
+					       spr_picsr[irqline] : 0;
 	      // Set
 		else if (!spr_picsr[irqline] & irq_unmasked[irqline])
 		  spr_picsr[irqline] <= 1;


### PR DESCRIPTION
It looks like idea of EDGE and LATCHED_LEVEL configurations doesn't reflect the difference in they way they require interrupts to be acknowledged. I think a way of acking should be unified in the way or1200 and the real software does it. The spec is good and all but people just can't do right what they can't test. For example
http://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/commit/?id=d23b5799b608112bb799c9b0e1e11ee1da692d76
seems to introduce wrong behavior in the #else case (not conformal to the spec, not compatible with current mor1kx EDGE trigger, scary warnings in runtime). I believe that we should change this according to the real world situation, remove unrealistic else cases, and just fix the spec.
