### PR TITLE
PIC: Make LEVEL triggered default

### DIFF
--- a/rtl/verilog/mor1kx.v
+++ b/rtl/verilog/mor1kx.v
@@ -65,7 +65,7 @@ module mor1kx
    parameter FEATURE_TRAP		= "ENABLED";
    parameter FEATURE_RANGE		= "ENABLED";
 
-   parameter OPTION_PIC_TRIGGER		= "EDGE";
+   parameter OPTION_PIC_TRIGGER		= "LEVEL";
 
    parameter FEATURE_DSX		= "ENABLED";
    parameter FEATURE_FASTCONTEXTS	= "NONE";

--- a/rtl/verilog/mor1kx_cfgrs.v
+++ b/rtl/verilog/mor1kx_cfgrs.v
@@ -54,7 +54,7 @@ module mor1kx_cfgrs
    parameter FEATURE_MAC                = "NONE";
    parameter FEATURE_FPU                = "NONE";   
 
-   parameter OPTION_PIC_TRIGGER         = "EDGE";
+   parameter OPTION_PIC_TRIGGER         = "LEVEL";
 
    parameter FEATURE_DSX                = "NONE";
    parameter FEATURE_FASTCONTEXTS       = "NONE";

--- a/rtl/verilog/mor1kx_cpu.v
+++ b/rtl/verilog/mor1kx_cpu.v
@@ -69,7 +69,7 @@ module mor1kx_cpu(/*AUTOARG*/
    parameter FEATURE_TRAP		= "ENABLED";
    parameter FEATURE_RANGE		= "ENABLED";
 
-   parameter OPTION_PIC_TRIGGER		= "EDGE";
+   parameter OPTION_PIC_TRIGGER		= "LEVEL";
 
    parameter FEATURE_DSX		= "NONE";
    parameter FEATURE_FASTCONTEXTS	= "NONE";

--- a/rtl/verilog/mor1kx_cpu_cappuccino.v
+++ b/rtl/verilog/mor1kx_cpu_cappuccino.v
@@ -61,7 +61,7 @@ module mor1kx_cpu_cappuccino
    parameter FEATURE_TRAP = "ENABLED";
    parameter FEATURE_RANGE = "ENABLED";
 
-   parameter OPTION_PIC_TRIGGER = "EDGE";
+   parameter OPTION_PIC_TRIGGER = "LEVEL";
 
    parameter FEATURE_DSX		= "NONE";
    parameter FEATURE_FASTCONTEXTS	= "NONE";

--- a/rtl/verilog/mor1kx_cpu_espresso.v
+++ b/rtl/verilog/mor1kx_cpu_espresso.v
@@ -57,7 +57,7 @@ module mor1kx_cpu_espresso
    parameter FEATURE_TRAP		= "ENABLED";
    parameter FEATURE_RANGE		= "ENABLED";
 
-   parameter OPTION_PIC_TRIGGER		= "EDGE";
+   parameter OPTION_PIC_TRIGGER		= "LEVEL";
 
    parameter FEATURE_DSX		= "NONE";
    parameter FEATURE_FASTCONTEXTS	= "NONE";

--- a/rtl/verilog/mor1kx_cpu_prontoespresso.v
+++ b/rtl/verilog/mor1kx_cpu_prontoespresso.v
@@ -57,7 +57,7 @@ module mor1kx_cpu_prontoespresso
    parameter FEATURE_TRAP		= "ENABLED";
    parameter FEATURE_RANGE		= "ENABLED";
 
-   parameter OPTION_PIC_TRIGGER		= "EDGE";
+   parameter OPTION_PIC_TRIGGER		= "LEVEL";
 
    parameter FEATURE_DSX		= "NONE";
    parameter FEATURE_FASTCONTEXTS	= "NONE";

--- a/rtl/verilog/mor1kx_ctrl_cappuccino.v
+++ b/rtl/verilog/mor1kx_ctrl_cappuccino.v
@@ -59,7 +59,7 @@ module mor1kx_ctrl_cappuccino
     parameter FEATURE_MAC = "NONE",
     parameter FEATURE_FPU = "NONE",
 
-    parameter OPTION_PIC_TRIGGER = "EDGE",
+    parameter OPTION_PIC_TRIGGER = "LEVEL",
 
     parameter FEATURE_DSX ="NONE",
     parameter FEATURE_FASTCONTEXTS = "NONE",

--- a/rtl/verilog/mor1kx_ctrl_espresso.v
+++ b/rtl/verilog/mor1kx_ctrl_espresso.v
@@ -79,7 +79,7 @@ module mor1kx_ctrl_espresso
    parameter FEATURE_MAC                = "NONE";
    parameter FEATURE_FPU                = "NONE";   
 
-   parameter OPTION_PIC_TRIGGER         = "EDGE";
+   parameter OPTION_PIC_TRIGGER         = "LEVEL";
 
    parameter FEATURE_DSX                = "NONE";
    parameter FEATURE_FASTCONTEXTS       = "NONE";

--- a/rtl/verilog/mor1kx_ctrl_prontoespresso.v
+++ b/rtl/verilog/mor1kx_ctrl_prontoespresso.v
@@ -80,7 +80,7 @@ module mor1kx_ctrl_prontoespresso
    parameter FEATURE_MAC                = "NONE";
    parameter FEATURE_FPU                = "NONE";   
 
-   parameter OPTION_PIC_TRIGGER         = "EDGE";
+   parameter OPTION_PIC_TRIGGER         = "LEVEL";
 
    parameter FEATURE_DSX                = "NONE";
    parameter FEATURE_FASTCONTEXTS       = "NONE";

--- a/rtl/verilog/mor1kx_pic.v
+++ b/rtl/verilog/mor1kx_pic.v
@@ -22,7 +22,7 @@ module mor1kx_pic
    clk, rst, irq_i, spr_we_i, spr_addr_i, spr_dat_i
    );
 
-   parameter OPTION_PIC_TRIGGER="EDGE";
+   parameter OPTION_PIC_TRIGGER="LEVEL";
 
    input clk;
    input rst;


### PR DESCRIPTION
The EDGE triggered PIC behaves exactly like the architecture spec.
Unfortunately, or1200 legacy is the incorrect behavior. LEVEL is the
same on both and even the spec says that is the common way. Therefore
change the default of mor1kx.
