### PR TITLE
LSU: Fix bug with lwa and snoop of same address

### DIFF
--- a/rtl/verilog/mor1kx_lsu_cappuccino.v
+++ b/rtl/verilog/mor1kx_lsu_cappuccino.v
@@ -452,11 +452,11 @@ if (FEATURE_ATOMIC!="NONE") begin : atomic_gen
    always @(posedge clk)
      if (rst | pipeline_flush_i)
        atomic_reserve <= 0;
-     else if (ctrl_op_lsu_load_i & ctrl_op_lsu_atomic_i & padv_ctrl_i)
-       atomic_reserve <= 1;
      else if ((ctrl_op_lsu_store_i & ctrl_op_lsu_atomic_i & padv_ctrl_i) ||
 	      store_buffer_write & (store_buffer_wadr == atomic_addr))
        atomic_reserve <= 0;
+     else if (ctrl_op_lsu_load_i & ctrl_op_lsu_atomic_i & padv_ctrl_i)
+       atomic_reserve <= 1;
 
    always @(posedge clk)
      if (ctrl_op_lsu_load_i & ctrl_op_lsu_atomic_i & padv_ctrl_i)


### PR DESCRIPTION
When a snoop event occurs parallel to the lwa completion, the swa
should fail. This is enabled by this patch that essentially simply
changes the order of checking.
