### PR TITLE
fpu32 support. prepare to pull request

### DIFF
--- a/rtl/verilog/mor1kx-defines.v
+++ b/rtl/verilog/mor1kx-defines.v
@@ -199,6 +199,36 @@
 `define OR1K_OPCODE_CUST8   {2'b11, 4'hF}
 
 //
+// ORFPX32 opcodes
+//
+`define OR1K_OPCODE_FPU  {2'b11, 4'h2}
+// FP OPs
+// MSbit indicates FPU operation valid
+`define OR1K_FPUOP_WIDTH	8
+`define OR1K_FPUOP_SELECT 7:0
+// FPU unit from Usselman takes 5 cycles from decode, so 4 ex. cycles
+`define OR1K_FPUOP_CYCLES 3'd4
+// FP instruction is double precision if bit 4 is set. We're a 32-bit 
+// implementation thus do not support double precision FP 
+`define OR1K_FPUOP_DOUBLE_BIT 4
+`define OR1K_FPUOP_ADD       8'b0000_0000
+`define OR1K_FPUOP_SUB       8'b0000_0001
+`define OR1K_FPUOP_MUL       8'b0000_0010
+`define OR1K_FPUOP_DIV       8'b0000_0011
+`define OR1K_FPUOP_ITOF      8'b0000_0100
+`define OR1K_FPUOP_FTOI      8'b0000_0101
+`define OR1K_FPUOP_REM       8'b0000_0110
+`define OR1K_FPUOP_RESERVED  8'b0000_0111
+// FP Compare instructions
+`define OR1K_FPCOP_SFEQ      8'b0000_1000
+`define OR1K_FPCOP_SFNE      8'b0000_1001
+`define OR1K_FPCOP_SFGT      8'b0000_1010
+`define OR1K_FPCOP_SFGE      8'b0000_1011
+`define OR1K_FPCOP_SFLT      8'b0000_1100
+`define OR1K_FPCOP_SFLE      8'b0000_1101
+
+
+//
 // OR1K SPR defines
 //
 `include "mor1kx-sprs.v"

--- a/rtl/verilog/mor1kx-sprs.v
+++ b/rtl/verilog/mor1kx-sprs.v
@@ -300,6 +300,45 @@
 `define OR1K_SPR_DRR_FPE  12
 `define OR1K_SPR_DRR_TE   13
 
+// FPCSR bits
+`define OR1K_FPCSR_FPEE  0
+`define OR1K_FPCSR_RM    2:1
+`define OR1K_FPCSR_OVF   3
+`define OR1K_FPCSR_UNF   4
+`define OR1K_FPCSR_SNF   5
+`define OR1K_FPCSR_QNF   6
+`define OR1K_FPCSR_ZF    7
+`define OR1K_FPCSR_IXF   8
+`define OR1K_FPCSR_IVF   9
+`define OR1K_FPCSR_INF   10
+`define OR1K_FPCSR_DZF   11
+// FPCSR sizes of fields
+`define OR1K_FPCSR_WIDTH    12 // [11:0]
+`define OR1K_FPCSR_RM_SIZE   2
+`define OR1K_FPCSR_ALLF_SIZE 9 // [11:3]
+// FPCSR flags
+`define OR1K_FPCSR_ALLF  `OR1K_FPCSR_DZF:`OR1K_FPCSR_OVF
+// FPCSR reset value
+`define OR1K_FPCSR_RESET_VALUE `OR1K_FPCSR_WIDTH'd1
+// FPCSR extention: maskable FPU flags.
+// -vvvv- uncomment the next line to switch the extention on -vvvv-
+//`define OR1K_FPCSR_MASK_FLAGS
+// bits
+`define OR1K_FPCSR_MASK_OVF   12
+`define OR1K_FPCSR_MASK_UNF   13
+`define OR1K_FPCSR_MASK_SNF   14
+`define OR1K_FPCSR_MASK_QNF   15
+`define OR1K_FPCSR_MASK_ZF    16
+`define OR1K_FPCSR_MASK_IXF   17
+`define OR1K_FPCSR_MASK_IVF   18
+`define OR1K_FPCSR_MASK_INF   19
+`define OR1K_FPCSR_MASK_DZF   20
+// bus select
+`define OR1K_FPCSR_MASK_ALL  `OR1K_FPCSR_MASK_DZF:`OR1K_FPCSR_MASK_OVF
+// reset value. enables: dzf,inf,ivf,snf,ovf
+`define OR1K_FPCSR_MASK_RESET_VALUE `OR1K_FPCSR_ALLF_SIZE'b1_1100_0101
+
+
 // Implementation-specific SPR defines
 `define MOR1KX_SPR_SR_WIDTH 16
 `define MOR1KX_SPR_SR_RESET_VALUE `MOR1KX_SPR_SR_WIDTH'h8001

--- a/rtl/verilog/mor1kx.v
+++ b/rtl/verilog/mor1kx.v
@@ -85,6 +85,8 @@ module mor1kx
     parameter FEATURE_CUST7		= "NONE",
     parameter FEATURE_CUST8		= "NONE",
 
+    parameter FEATURE_FPU     = "NONE", // ENABLED|NONE: actual for cappuccino pipeline only
+    
     parameter OPTION_SHIFTER		= "BARREL",
 
     parameter FEATURE_STORE_BUFFER	= "ENABLED",
@@ -499,6 +501,7 @@ module mor1kx
 	     .FEATURE_CMOV(FEATURE_CMOV),
 	     .FEATURE_FFL1(FEATURE_FFL1),
 	     .FEATURE_ATOMIC(FEATURE_ATOMIC),
+	     .FEATURE_FPU(FEATURE_FPU), // mor1kx_cpu instance
 	     .FEATURE_CUST1(FEATURE_CUST1),
 	     .FEATURE_CUST2(FEATURE_CUST2),
 	     .FEATURE_CUST3(FEATURE_CUST3),

--- a/rtl/verilog/mor1kx_cfgrs.v
+++ b/rtl/verilog/mor1kx_cfgrs.v
@@ -72,7 +72,6 @@ module mor1kx_cfgrs
     output [31:0] spr_iccfgr,
     output [31:0] spr_dcfgr,
     output [31:0] spr_pccfgr,
-    output [31:0] spr_fpcsr,
     output [31:0] spr_avr
     );
 
@@ -100,7 +99,7 @@ module mor1kx_cfgrs
    assign spr_cpucfgr[`OR1K_SPR_CPUCFGR_CFG] = 0;
    assign spr_cpucfgr[`OR1K_SPR_CPUCFGR_OB32S] = 1;
    assign spr_cpucfgr[`OR1K_SPR_CPUCFGR_OB64S] = 0;
-   assign spr_cpucfgr[`OR1K_SPR_CPUCFGR_OF32S] = 0;
+   assign spr_cpucfgr[`OR1K_SPR_CPUCFGR_OF32S] = (FEATURE_FPU!="NONE");
    assign spr_cpucfgr[`OR1K_SPR_CPUCFGR_OF64S] = 0;
    assign spr_cpucfgr[`OR1K_SPR_CPUCFGR_OV64S] = 0;
    assign spr_cpucfgr[`OR1K_SPR_CPUCFGR_ND] = (FEATURE_DELAYSLOT=="NONE");
@@ -236,6 +235,5 @@ module mor1kx_cfgrs
 
    assign spr_dcfgr = 0;
    assign spr_pccfgr = 0;
-   assign spr_fpcsr = 0;
 
 endmodule // mor1kx_cfgrs

--- a/rtl/verilog/mor1kx_cpu.v
+++ b/rtl/verilog/mor1kx_cpu.v
@@ -86,6 +86,8 @@ module mor1kx_cpu
     parameter FEATURE_CSYNC		= "NONE",
     parameter FEATURE_ATOMIC		= "ENABLED",
 
+    parameter FEATURE_FPU		= "NONE", // ENABLED|NONE
+
     parameter FEATURE_CUST1		= "NONE",
     parameter FEATURE_CUST2		= "NONE",
     parameter FEATURE_CUST3		= "NONE",
@@ -248,6 +250,7 @@ module mor1kx_cpu
 	     .FEATURE_PSYNC(FEATURE_PSYNC),
 	     .FEATURE_CSYNC(FEATURE_CSYNC),
 	     .FEATURE_ATOMIC(FEATURE_ATOMIC),
+	     .FEATURE_FPU(FEATURE_FPU), // cappuccino pipe instance
 	     .FEATURE_CUST1(FEATURE_CUST1),
 	     .FEATURE_CUST2(FEATURE_CUST2),
 	     .FEATURE_CUST3(FEATURE_CUST3),
@@ -391,6 +394,7 @@ module mor1kx_cpu
 	     .FEATURE_MSYNC(FEATURE_MSYNC),
 	     .FEATURE_PSYNC(FEATURE_PSYNC),
 	     .FEATURE_CSYNC(FEATURE_CSYNC),
+	     .FEATURE_FPU("NONE"), // espresso pipe instance
 	     .FEATURE_CUST1(FEATURE_CUST1),
 	     .FEATURE_CUST2(FEATURE_CUST2),
 	     .FEATURE_CUST3(FEATURE_CUST3),
@@ -521,6 +525,7 @@ module mor1kx_cpu
 	     .FEATURE_MSYNC(FEATURE_MSYNC),
 	     .FEATURE_PSYNC(FEATURE_PSYNC),
 	     .FEATURE_CSYNC(FEATURE_CSYNC),
+	     .FEATURE_FPU("NONE"), // prontoespresso pipe instance
 	     .FEATURE_CUST1(FEATURE_CUST1),
 	     .FEATURE_CUST2(FEATURE_CUST2),
 	     .FEATURE_CUST3(FEATURE_CUST3),

--- a/rtl/verilog/mor1kx_decode.v
+++ b/rtl/verilog/mor1kx_decode.v
@@ -47,6 +47,8 @@ module mor1kx_decode
     parameter FEATURE_PSYNC = "NONE",
     parameter FEATURE_CSYNC = "NONE",
 
+    parameter FEATURE_FPU   = "NONE", // ENABLED|NONE
+
     parameter FEATURE_CUST1 = "NONE",
     parameter FEATURE_CUST2 = "NONE",
     parameter FEATURE_CUST3 = "NONE",
@@ -115,6 +117,8 @@ module mor1kx_decode
 
     // Sync operations
     output                            decode_op_msync_o,
+    output [`OR1K_FPUOP_WIDTH-1:0]    decode_op_fpu_o,
+
 
     // Adder control logic
     output 			      decode_adder_do_sub_o,
@@ -259,6 +263,19 @@ module mor1kx_decode
 
    assign decode_op_movhi_o = opc_insn == `OR1K_OPCODE_MOVHI;
 
+   // FPU related
+   generate
+     /* verilator lint_off WIDTH */
+     if (FEATURE_FPU!="NONE") begin : fpu_decode_ena
+     /* verilator lint_on WIDTH */
+       assign decode_op_fpu_o  = { (opc_insn == `OR1K_OPCODE_FPU), 
+                                   decode_insn_i[`OR1K_FPUOP_WIDTH-2:0] };
+     end
+     else begin : fpu_decode_none
+       assign decode_op_fpu_o  = {`OR1K_FPUOP_WIDTH{1'b0}};
+     end
+   endgenerate // FPU related
+
    // Which instructions cause writeback?
    assign decode_rf_wb_o = (opc_insn == `OR1K_OPCODE_JAL |
 			    opc_insn == `OR1K_OPCODE_MOVHI |
@@ -401,6 +418,8 @@ module mor1kx_decode
 	 decode_except_illegal_o = (FEATURE_CUST7=="NONE");
        `OR1K_OPCODE_CUST8:
 	 decode_except_illegal_o = (FEATURE_CUST8=="NONE");
+       `OR1K_OPCODE_FPU:
+	 decode_except_illegal_o = (FEATURE_FPU=="NONE");
 
        `OR1K_OPCODE_LD,
 	 `OR1K_OPCODE_SD:

--- a/rtl/verilog/pfpu32/pfpu32_addsub.v
+++ b/rtl/verilog/pfpu32/pfpu32_addsub.v
@@ -1,0 +1,338 @@
+//////////////////////////////////////////////////////////////////////
+//                                                                  //
+//    pfpu32_addsub                                                 //
+//                                                                  //
+//    This file is part of the mor1kx project                       //
+//    https://github.com/openrisc/mor1kx                            //
+//                                                                  //
+//    Description                                                   //
+//    addition/subtraction pipeline for single precision floating   //
+//    point numbers                                                 //
+//                                                                  //
+//    Author(s):                                                    //
+//        - Original design (FPU100) -                              //
+//          Jidan Al-eryani, jidan@gmx.net                          //
+//        - Conv. to Verilog and inclusion in OR1200 -              //
+//          Julius Baxter, julius@opencores.org                     //
+//        - Update for mor1kx,                                      //
+//          bug fixing and further development -                    //
+//          Andrey Bacherov, avbacherov@opencores.org               //
+//                                                                  //
+//////////////////////////////////////////////////////////////////////
+//                                                                  //
+//  Copyright (C) 2006, 2010, 2014                                  //
+//                                                                  //
+//  This source file may be used and distributed without            //
+//  restriction provided that this copyright statement is not       //
+//  removed from the file and that any derivative work contains     //
+//  the original copyright notice and the associated disclaimer.    //
+//                                                                  //
+//    THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY           //
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED       //
+//  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS       //
+//  FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL THE AUTHOR          //
+//  OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,             //
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        //
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE       //
+//  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR            //
+//  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF      //
+//  LIABILITY, WHETHER IN  CONTRACT, STRICT LIABILITY, OR TORT      //
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT      //
+//  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE             //
+//  POSSIBILITY OF SUCH DAMAGE.                                     //
+//////////////////////////////////////////////////////////////////////
+
+`include "mor1kx-defines.v"
+
+
+module pfpu32_addsub
+(
+   input             clk,
+   input             rst,
+   input             flush_i,  // flushe pipe
+   input             adv_i,    // advance pipe
+   input             start_i,  // start add/sub
+   input             is_sub_i, // 1: substruction, 0: addition
+   // input 'a' related values
+   input             signa_i,
+   input       [9:0] exp10a_i,
+   input      [23:0] fract24a_i,
+   input             infa_i,
+   // input 'b' related values
+   input             signb_i,
+   input       [9:0] exp10b_i,
+   input      [23:0] fract24b_i,
+   input             infb_i,
+   // 'a'/'b' related
+   input             snan_i,
+   input             qnan_i,
+   input             anan_sign_i,
+   input             addsub_agtb_i,
+   input             addsub_aeqb_i,
+   // outputs
+   output reg        add_rdy_o,       // ready
+   output reg        add_sign_o,      // signum
+   output reg        add_sub_0_o,     // flag that actual substruction is performed and result is zero
+   output reg  [4:0] add_shl_o,       // do left shift in align stage
+   output reg  [9:0] add_exp10shl_o,  // exponent for left shift align
+   output reg  [9:0] add_exp10sh0_o,  // exponent for no shift in align
+   output reg [27:0] add_fract28_o,   // fractional with appended {r,s} bits
+   output reg        add_inv_o,       // invalid operation flag
+   output reg        add_inf_o,       // infinity output reg
+   output reg        add_snan_o,      // signaling NaN output reg
+   output reg        add_qnan_o,      // quiet NaN output reg
+   output reg        add_anan_sign_o  // signum for output nan
+);
+  /*
+     Any stage's output is registered.
+     Definitions:
+       s??o_name - "S"tage number "??", "O"utput
+       s??t_name - "S"tage number "??", "T"emporary (internally)
+  */
+
+  /* Stage #1: pre addition / substruction align */
+
+    // detection of some exceptions
+    //   inf - inf -> invalid operation; snan output
+  wire s1t_inv = infa_i & infb_i &
+                 (signa_i ^ (is_sub_i ^ signb_i));
+    //   inf input
+  wire s1t_inf_i = infa_i | infb_i;
+
+    // signums for calculation
+  wire s1t_calc_signa = signa_i;
+  wire s1t_calc_signb = (signb_i ^ is_sub_i);
+
+    // not shifted operand and its signum
+  wire [23:0] s1t_fract24_nsh =
+    addsub_agtb_i ? fract24a_i : fract24b_i;
+
+    // operand for right shift
+  wire [23:0] s1t_fract24_fsh =
+    addsub_agtb_i ? fract24b_i : fract24a_i;
+
+    // shift amount
+  wire [9:0] s1t_exp_diff =
+    addsub_agtb_i ? (exp10a_i - exp10b_i) :
+                    (exp10b_i - exp10a_i);
+
+  // limiter by 31
+  wire [4:0] s1t_shr = s1t_exp_diff[4:0] | {5{|s1t_exp_diff[9:5]}};
+
+  // stage #1 outputs
+  //  input related
+  reg s1o_inv, s1o_inf_i,
+      s1o_snan_i, s1o_qnan_i, s1o_anan_i_sign;
+  //  computation related
+  reg        s1o_aeqb;
+  reg  [4:0] s1o_shr;
+  reg        s1o_sign_nsh;
+  reg        s1o_op_sub;
+  reg  [9:0] s1o_exp10c;
+  reg [23:0] s1o_fract24_nsh;
+  reg [23:0] s1o_fract24_fsh;
+  //  registering
+  always @(posedge clk) begin
+    if(adv_i) begin
+        // input related
+      s1o_inv         <= s1t_inv;
+      s1o_inf_i       <= s1t_inf_i;
+      s1o_snan_i      <= snan_i;
+      s1o_qnan_i      <= qnan_i;
+      s1o_anan_i_sign <= anan_sign_i;
+        // computation related
+      s1o_aeqb        <= addsub_aeqb_i;
+      s1o_shr         <= s1t_shr & {5{~s1t_inf_i}};
+      s1o_sign_nsh    <= addsub_agtb_i ? s1t_calc_signa : s1t_calc_signb;
+      s1o_op_sub      <= s1t_calc_signa ^ s1t_calc_signb;
+      s1o_exp10c      <= addsub_agtb_i ? exp10a_i : exp10b_i;
+      s1o_fract24_nsh <= s1t_fract24_nsh & {24{~s1t_inf_i}};
+      s1o_fract24_fsh <= s1t_fract24_fsh & {24{~s1t_inf_i}};
+    end // advance
+  end // posedge clock
+
+  // ready is special case
+  reg s1o_ready;
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst)
+      s1o_ready  <= 0;
+    else if(flush_i)
+      s1o_ready  <= 0;
+    else if(adv_i)
+      s1o_ready <= start_i;
+  end // posedge clock
+
+
+  /* Stage 2: multiplex and shift */
+
+
+  // shifter
+  wire [25:0] s2t_fract26_fsh = {s1o_fract24_fsh,2'd0};
+  wire [25:0] s2t_fract26_shr = s2t_fract26_fsh >> s1o_shr;
+  
+  // sticky
+  reg s2t_sticky;
+  always @(s1o_shr or s1o_fract24_fsh) begin
+    case(s1o_shr)
+      5'd0, 5'd1, 5'd2 : s2t_sticky = 1'b0; // two added zero bits
+      5'd3 : s2t_sticky = s1o_fract24_fsh[0];
+      5'd4 : s2t_sticky = |s1o_fract24_fsh[1:0];
+      5'd5 : s2t_sticky = |s1o_fract24_fsh[2:0];
+      5'd6 : s2t_sticky = |s1o_fract24_fsh[3:0];
+      5'd7 : s2t_sticky = |s1o_fract24_fsh[4:0];
+      5'd8 : s2t_sticky = |s1o_fract24_fsh[5:0];
+      5'd9 : s2t_sticky = |s1o_fract24_fsh[6:0];
+      5'd10: s2t_sticky = |s1o_fract24_fsh[7:0];
+      5'd11: s2t_sticky = |s1o_fract24_fsh[8:0];
+      5'd12: s2t_sticky = |s1o_fract24_fsh[9:0];
+      5'd13: s2t_sticky = |s1o_fract24_fsh[10:0];
+      5'd14: s2t_sticky = |s1o_fract24_fsh[11:0];
+      5'd15: s2t_sticky = |s1o_fract24_fsh[12:0];
+      5'd16: s2t_sticky = |s1o_fract24_fsh[13:0];
+      5'd17: s2t_sticky = |s1o_fract24_fsh[14:0];
+      5'd18: s2t_sticky = |s1o_fract24_fsh[15:0];
+      5'd19: s2t_sticky = |s1o_fract24_fsh[16:0];
+      5'd20: s2t_sticky = |s1o_fract24_fsh[17:0];
+      5'd21: s2t_sticky = |s1o_fract24_fsh[18:0];
+      5'd22: s2t_sticky = |s1o_fract24_fsh[19:0];
+      5'd23: s2t_sticky = |s1o_fract24_fsh[20:0];
+      5'd24: s2t_sticky = |s1o_fract24_fsh[21:0];
+      5'd25: s2t_sticky = |s1o_fract24_fsh[22:0];
+      default: s2t_sticky = |s1o_fract24_fsh[23:0];
+    endcase
+  end
+
+    // add/sub of non-shifted and shifted operands
+  wire [27:0] s2t_fract28_shr = {1'b0,s2t_fract26_shr,s2t_sticky};
+  
+  wire [27:0] s2t_fract28_add = {1'b0,s1o_fract24_nsh,3'd0} +
+                                (s2t_fract28_shr ^ {28{s1o_op_sub}}) +
+                                {27'd0,s1o_op_sub};
+
+
+  // stage #2 outputs
+  //  input related
+  reg s2o_inv, s2o_inf_i,
+      s2o_snan_i, s2o_qnan_i, s2o_anan_i_sign;
+  //  computational related
+  reg        s2o_signc;
+  reg [9:0]  s2o_exp10c;
+  reg [26:0] s2o_fract27;
+  reg        s2o_sub_0;       // actual operation is substruction and the result is zero
+  reg        s2o_sticky;      // rounding support
+  //  registering
+  always @(posedge clk) begin
+    if(adv_i) begin
+        // input related
+      s2o_inv         <= s1o_inv;
+      s2o_inf_i       <= s1o_inf_i;
+      s2o_snan_i      <= s1o_snan_i;
+      s2o_qnan_i      <= s1o_qnan_i;
+      s2o_anan_i_sign <= s1o_anan_i_sign;
+        // computation related
+      s2o_signc       <= s1o_sign_nsh;
+      s2o_exp10c      <= s1o_exp10c;
+      s2o_fract27     <= s2t_fract28_add[27:1];
+      s2o_sub_0       <= s1o_aeqb & s1o_op_sub;
+      s2o_sticky      <= s2t_sticky;
+    end // advance
+  end // posedge clock
+
+  // ready is special case
+  reg s2o_ready;
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst)
+      s2o_ready  <= 0;
+    else if(flush_i)
+      s2o_ready  <= 0;
+    else if(adv_i)
+      s2o_ready <= s1o_ready;
+  end // posedge clock
+
+
+  /* Stage 4: update exponent */
+
+
+  // for possible left shift
+  // [26] bit is right shift flag
+  reg [4:0] s3t_nlz;
+  always @(s2o_fract27) begin
+    casez(s2o_fract27)
+      27'b1??????????????????????????: s3t_nlz <=  0; // [26] bit: shift right
+      27'b01?????????????????????????: s3t_nlz <=  0; // 1 is in place
+      27'b001????????????????????????: s3t_nlz <=  1;
+      27'b0001???????????????????????: s3t_nlz <=  2;
+      27'b00001??????????????????????: s3t_nlz <=  3;
+      27'b000001?????????????????????: s3t_nlz <=  4;
+      27'b0000001????????????????????: s3t_nlz <=  5;
+      27'b00000001???????????????????: s3t_nlz <=  6;
+      27'b000000001??????????????????: s3t_nlz <=  7;
+      27'b0000000001?????????????????: s3t_nlz <=  8;
+      27'b00000000001????????????????: s3t_nlz <=  9;
+      27'b000000000001???????????????: s3t_nlz <= 10;
+      27'b0000000000001??????????????: s3t_nlz <= 11;
+      27'b00000000000001?????????????: s3t_nlz <= 12;
+      27'b000000000000001????????????: s3t_nlz <= 13;
+      27'b0000000000000001???????????: s3t_nlz <= 14;
+      27'b00000000000000001??????????: s3t_nlz <= 15;
+      27'b000000000000000001?????????: s3t_nlz <= 16;
+      27'b0000000000000000001????????: s3t_nlz <= 17;
+      27'b00000000000000000001???????: s3t_nlz <= 18;
+      27'b000000000000000000001??????: s3t_nlz <= 19;
+      27'b0000000000000000000001?????: s3t_nlz <= 20;
+      27'b00000000000000000000001????: s3t_nlz <= 21;
+      27'b000000000000000000000001???: s3t_nlz <= 22;
+      27'b0000000000000000000000001??: s3t_nlz <= 23;
+      27'b00000000000000000000000001?: s3t_nlz <= 24;
+      27'b000000000000000000000000001: s3t_nlz <= 25;
+      27'b000000000000000000000000000: s3t_nlz <=  0; // zero result
+    endcase
+  end // always
+
+  // left shift amount and corrected exponent
+  wire [4:0] s3t_nlz_m1    = (s3t_nlz - 5'd1);
+  wire [9:0] s3t_exp10c_m1 = s2o_exp10c - 10'd1;
+  wire [9:0] s3t_exp10c_mz = s2o_exp10c - {5'd0,s3t_nlz};
+  wire [4:0] s3t_shl;
+  wire [9:0] s3t_exp10shl;
+  assign {s3t_shl,s3t_exp10shl} =
+      // shift isn't needed or impossible
+    (~(|s3t_nlz) | (s2o_exp10c == 10'd1)) ?
+                              {5'd0,s2o_exp10c} :
+      // normalization is possible
+    (s2o_exp10c >  s3t_nlz) ? {s3t_nlz,s3t_exp10c_mz} :
+      // denormalized cases
+    (s2o_exp10c == s3t_nlz) ? {s3t_nlz_m1,10'd1} :
+                              {s3t_exp10c_m1[4:0],10'd1};
+
+
+  // registering output
+  always @(posedge clk) begin
+    if(adv_i) begin
+        // input related
+      add_inv_o       <= s2o_inv;
+      add_inf_o       <= s2o_inf_i;
+      add_snan_o      <= s2o_snan_i;
+      add_qnan_o      <= s2o_qnan_i;
+      add_anan_sign_o <= s2o_anan_i_sign;
+        // computation related
+      add_sign_o      <= s2o_signc;
+      add_sub_0_o     <= s2o_sub_0;
+      add_shl_o       <= s3t_shl;
+      add_exp10shl_o  <= s3t_exp10shl;
+      add_exp10sh0_o  <= s2o_exp10c;
+      add_fract28_o   <= {s2o_fract27,s2o_sticky};
+    end // advance
+  end // posedge clock
+
+  // ready is special case
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst)
+      add_rdy_o <= 0;
+    else if(flush_i)
+      add_rdy_o <= 0;
+    else if(adv_i)
+      add_rdy_o <= s2o_ready;
+  end // posedge clock
+
+endmodule // pfpu32_addsub

--- a/rtl/verilog/pfpu32/pfpu32_cmp.v
+++ b/rtl/verilog/pfpu32/pfpu32_cmp.v
@@ -1,0 +1,180 @@
+/////////////////////////////////////////////////////////////////////
+////                                                             ////
+////  pfpu32_cmp                                                 ////
+////  32-bit floating point comparision                          ////
+////                                                             ////
+////  Author: Rudolf Usselmann                                   ////
+////          rudi@asics.ws                                      ////
+////                                                             ////
+////  Modified by Julius Baxter, July, 2010                      ////
+////              julius.baxter@orsoc.se                         ////
+////                                                             ////
+////  Update for mor1kx, bug fixing and further development      ////
+////              Andrey Bacherov, 2014,                         ////
+////              avbacherov@opencores.org                       ////
+////                                                             ////
+/////////////////////////////////////////////////////////////////////
+////                                                             ////
+//// Copyright (C) 2000 Rudolf Usselmann                         ////
+////                    rudi@asics.ws                            ////
+////                                                             ////
+//// This source file may be used and distributed without        ////
+//// restriction provided that this copyright statement is not   ////
+//// removed from the file and that any derivative work contains ////
+//// the original copyright notice and the associated disclaimer.////
+////                                                             ////
+////     THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY     ////
+//// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   ////
+//// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS   ////
+//// FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL THE AUTHOR      ////
+//// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,         ////
+//// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES    ////
+//// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE   ////
+//// GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR        ////
+//// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF  ////
+//// LIABILITY, WHETHER IN  CONTRACT, STRICT LIABILITY, OR TORT  ////
+//// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  ////
+//// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         ////
+//// POSSIBILITY OF SUCH DAMAGE.                                 ////
+////                                                             ////
+/////////////////////////////////////////////////////////////////////
+
+`include "mor1kx-defines.v"
+
+/* completely combinatorial module */
+
+module pfpu32_fcmp
+(
+  input fpu_op_is_comp_i,
+  input [`OR1K_FPUOP_WIDTH-1:0] cmp_type_i,
+  // operand 'a' related inputs
+  input        signa_i,
+  input  [9:0] exp10a_i,
+  input [23:0] fract24a_i,
+  input        snana_i,
+  input        qnana_i,
+  input        infa_i,
+  input        zeroa_i,
+  // operand 'b' related inputs
+  input        signb_i,
+  input  [9:0] exp10b_i,
+  input [23:0] fract24b_i,
+  input        snanb_i,
+  input        qnanb_i,
+  input        infb_i,
+  input        zerob_i,
+  // support addsub
+  output addsub_agtb_o,
+  output addsub_aeqb_o,
+  // outputs
+  output cmp_flag_o, inv_o, inf_o, ready_o
+);
+
+////////////////////////////////////////////////////////////////////////
+//
+// Exception Logic
+//
+
+wire qnan = qnana_i | qnanb_i;
+wire snan = snana_i | snanb_i;
+wire anan = qnan | snan;
+
+
+// Comparison invalid when sNaN in on an equal comparison,
+// or any NaN for any other comparison.
+wire inv_cmp = (snan & (cmp_type_i == `OR1K_FPCOP_SFEQ)) |
+               (anan & (cmp_type_i != `OR1K_FPCOP_SFEQ));
+
+
+////////////////////////////////////////////////////////////////////////
+//
+// Comparison Logic
+//
+wire exp_gt = exp10a_i  > exp10b_i;
+wire exp_eq = exp10a_i == exp10b_i;
+wire exp_lt = (~exp_gt) & (~exp_eq); // exp10a_i  < exp10b_i;
+
+wire fract_gt = fract24a_i  > fract24b_i;
+wire fract_eq = fract24a_i == fract24b_i;
+wire fract_lt = (~fract_gt) & (~fract_eq); // fract24a_i  < fract24b_i;
+
+wire all_zero = zeroa_i & zerob_i;
+
+reg altb, blta, aeqb;
+
+always @( qnan or snan or infa_i or infb_i or signa_i or signb_i or
+          exp_eq or exp_gt or exp_lt or
+          fract_eq or fract_gt or fract_lt or all_zero)
+
+  casez( {qnan, snan, infa_i, infb_i, signa_i, signb_i,
+          exp_eq, exp_gt, exp_lt,
+          fract_eq, fract_gt, fract_lt, all_zero})
+    13'b1?_??_??_???_???_?: {blta, altb, aeqb} = 3'b000; // qnan
+    13'b?1_??_??_???_???_?: {blta, altb, aeqb} = 3'b000; // snan
+
+    13'b00_11_00_???_???_?: {blta, altb, aeqb} = 3'b001; // both op INF comparisson
+    13'b00_11_01_???_???_?: {blta, altb, aeqb} = 3'b100;
+    13'b00_11_10_???_???_?: {blta, altb, aeqb} = 3'b010;
+    13'b00_11_11_???_???_?: {blta, altb, aeqb} = 3'b001;
+
+    13'b00_10_00_???_???_?: {blta, altb, aeqb} = 3'b100; // opa_i INF comparisson
+    13'b00_10_01_???_???_?: {blta, altb, aeqb} = 3'b100;
+    13'b00_10_10_???_???_?: {blta, altb, aeqb} = 3'b010;
+    13'b00_10_11_???_???_?: {blta, altb, aeqb} = 3'b010;
+
+    13'b00_01_00_???_???_?: {blta, altb, aeqb} = 3'b010; // opb_i INF comparisson
+    13'b00_01_01_???_???_?: {blta, altb, aeqb} = 3'b100;
+    13'b00_01_10_???_???_?: {blta, altb, aeqb} = 3'b010;
+    13'b00_01_11_???_???_?: {blta, altb, aeqb} = 3'b100;
+
+    13'b00_00_10_???_???_0: {blta, altb, aeqb} = 3'b010; //compare base on sign
+    13'b00_00_01_???_???_0: {blta, altb, aeqb} = 3'b100; //compare base on sign
+
+    13'b00_00_??_???_???_1: {blta, altb, aeqb} = 3'b001; //compare base on sign both are zero
+
+    13'b00_00_00_010_???_?: {blta, altb, aeqb} = 3'b100; // cmp exp, equal sign
+    13'b00_00_00_001_???_?: {blta, altb, aeqb} = 3'b010;
+    13'b00_00_11_010_???_?: {blta, altb, aeqb} = 3'b010;
+    13'b00_00_11_001_???_?: {blta, altb, aeqb} = 3'b100;
+
+    13'b00_00_00_100_010_?: {blta, altb, aeqb} = 3'b100; // compare fractions, equal sign, equal exp
+    13'b00_00_00_100_001_?: {blta, altb, aeqb} = 3'b010;
+    13'b00_00_11_100_010_?: {blta, altb, aeqb} = 3'b010;
+    13'b00_00_11_100_001_?: {blta, altb, aeqb} = 3'b100;
+
+    13'b00_00_00_100_100_?: {blta, altb, aeqb} = 3'b001;
+    13'b00_00_11_100_100_?: {blta, altb, aeqb} = 3'b001;
+
+    default: {blta, altb, aeqb} = 3'b000;
+  endcase
+
+
+////////////////////////////////////////////////////////////////////////
+// Comparison cmp_flag generation
+reg cmp_flag;
+always @(altb or blta or aeqb or cmp_type_i)
+  begin
+    case(cmp_type_i)
+      `OR1K_FPCOP_SFEQ: cmp_flag = aeqb;
+      `OR1K_FPCOP_SFNE: cmp_flag = !aeqb;
+      `OR1K_FPCOP_SFGT: cmp_flag = blta & !aeqb;
+      `OR1K_FPCOP_SFGE: cmp_flag = blta | aeqb;
+      `OR1K_FPCOP_SFLT: cmp_flag = altb & !aeqb;
+      `OR1K_FPCOP_SFLE: cmp_flag = altb | aeqb;
+      default:          cmp_flag = 0;
+    endcase // case (fpu_op_r)
+  end // always@ *
+
+
+////////////////////////////////////////////////////////////////////////
+// output (latching is perfommed on FPU top level)
+
+assign addsub_agtb_o = exp_gt | (exp_eq & fract_gt);
+assign addsub_aeqb_o = exp_eq & fract_eq;
+
+assign cmp_flag_o = cmp_flag;
+assign inv_o      = inv_cmp;
+assign inf_o      = infa_i | infb_i;
+assign ready_o    = fpu_op_is_comp_i;
+
+endmodule // pfpu32_fcmp

--- a/rtl/verilog/pfpu32/pfpu32_f2i.v
+++ b/rtl/verilog/pfpu32/pfpu32_f2i.v
@@ -1,0 +1,110 @@
+/////////////////////////////////////////////////////////////////////
+////                                                             ////
+////  pfpu32_f2i                                                 ////
+////  32-bit floating point to integer converter                 ////
+////                                                             ////
+////  Author: Andrey Bacherov                                    ////
+////          avbacherov@opencores.org                           ////
+////                                                             ////
+/////////////////////////////////////////////////////////////////////
+////                                                             ////
+//// Copyright (C) 2014 Andrey Bacherov                          ////
+////                    avbacherov@opencores.org                 ////
+////                                                             ////
+//// This source file may be used and distributed without        ////
+//// restriction provided that this copyright statement is not   ////
+//// removed from the file and that any derivative work contains ////
+//// the original copyright notice and the associated disclaimer.////
+////                                                             ////
+////     THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY     ////
+//// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   ////
+//// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS   ////
+//// FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL THE AUTHOR      ////
+//// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,         ////
+//// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES    ////
+//// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE   ////
+//// GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR        ////
+//// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF  ////
+//// LIABILITY, WHETHER IN  CONTRACT, STRICT LIABILITY, OR TORT  ////
+//// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  ////
+//// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         ////
+//// POSSIBILITY OF SUCH DAMAGE.                                 ////
+////                                                             ////
+/////////////////////////////////////////////////////////////////////
+
+`include "mor1kx-defines.v"
+
+module pfpu32_f2i
+(
+   input             clk,
+   input             rst,
+   input             flush_i,  // flush pipe
+   input             adv_i,    // advance pipe
+   input             start_i,  // start conversion
+   input             signa_i,  // input 'a' related values
+   input       [9:0] exp10a_i,
+   input      [23:0] fract24a_i,
+   input             snan_i,   // 'a'/'b' related
+   input             qnan_i,
+   output reg        f2i_rdy_o,       // f2i is ready
+   output reg        f2i_sign_o,      // f2i signum
+   output reg [23:0] f2i_int24_o,     // f2i fractional
+   output reg  [4:0] f2i_shr_o,       // f2i required shift right value
+   output reg  [3:0] f2i_shl_o,       // f2i required shift left value   
+   output reg        f2i_ovf_o,       // f2i overflow flag
+   output reg        f2i_snan_o       // f2i signaling NaN output reg
+);
+
+  /*
+     Any stage's output is registered.
+     Definitions:
+       s??o_name - "S"tage number "??", "O"utput
+       s??t_name - "S"tage number "??", "T"emporary (internally)
+  */
+
+  // exponent after moving binary point at the end of mantissa
+  // bias is also removed
+  wire [9:0] s1t_exp10m = exp10a_i - 10'd150; // (- 127 - 23)
+
+  // detect if now shift right is required
+  wire [9:0] s1t_shr_t = {10{s1t_exp10m[9]}} & (10'd150 - exp10a_i);
+  // limit right shift by 31
+  wire [4:0] s1t_shr = s1t_shr_t[4:0] | {5{|s1t_shr_t[9:5]}};
+
+  // detect if left shift required for mantissa
+  // (limited by 15)
+  wire [3:0] s1t_shl = {4{~s1t_exp10m[9]}} & (s1t_exp10m[3:0] | {4{|s1t_exp10m[9:4]}});
+  // check overflow
+  wire s1t_is_shl_gt8 = s1t_shl[3] & (|s1t_shl[2:0]);
+  wire s1t_is_shl_eq8 = s1t_shl[3] & (~(|s1t_shl[2:0]));
+  wire s1t_is_shl_ovf =
+     s1t_is_shl_gt8 |
+    (s1t_is_shl_eq8 & (~signa_i)) |
+    (s1t_is_shl_eq8 &   signa_i & (|fract24a_i[22:0]));
+
+
+  // registering output
+  always @(posedge clk) begin
+    if(adv_i) begin
+        // input related
+      f2i_snan_o  <= snan_i;
+        // computation related
+      f2i_sign_o  <= signa_i & (!(qnan_i | snan_i)); // if 'a' is a NaN than ouput is max. positive
+      f2i_int24_o <= fract24a_i;
+      f2i_shr_o   <= s1t_shr;
+      f2i_shl_o   <= s1t_shl;
+      f2i_ovf_o   <= s1t_is_shl_ovf;
+    end // (reset or flush) / advance
+  end // posedge clock
+
+  // ready is special case
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst)
+      f2i_rdy_o <= 1'b0;
+    else if(flush_i)
+      f2i_rdy_o <= 1'b0;
+    else if(adv_i)
+      f2i_rdy_o <= start_i;
+  end // posedge clock
+ 
+endmodule // pfpu32_f2i

--- a/rtl/verilog/pfpu32/pfpu32_i2f.v
+++ b/rtl/verilog/pfpu32/pfpu32_i2f.v
@@ -1,0 +1,144 @@
+/////////////////////////////////////////////////////////////////////
+////                                                             ////
+////  pfpu32_i2f                                                 ////
+////  32-bit integer to floating point converter                 ////
+////                                                             ////
+////  Author: Andrey Bacherov                                    ////
+////          avbacherov@opencores.org                           ////
+////                                                             ////
+/////////////////////////////////////////////////////////////////////
+////                                                             ////
+//// Copyright (C) 2014 Andrey Bacherov                          ////
+////                    avbacherov@opencores.org                 ////
+////                                                             ////
+//// This source file may be used and distributed without        ////
+//// restriction provided that this copyright statement is not   ////
+//// removed from the file and that any derivative work contains ////
+//// the original copyright notice and the associated disclaimer.////
+////                                                             ////
+////     THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY     ////
+//// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   ////
+//// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS   ////
+//// FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL THE AUTHOR      ////
+//// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,         ////
+//// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES    ////
+//// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE   ////
+//// GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR        ////
+//// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF  ////
+//// LIABILITY, WHETHER IN  CONTRACT, STRICT LIABILITY, OR TORT  ////
+//// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  ////
+//// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         ////
+//// POSSIBILITY OF SUCH DAMAGE.                                 ////
+////                                                             ////
+/////////////////////////////////////////////////////////////////////
+
+`include "mor1kx-defines.v"
+
+module pfpu32_i2f
+(
+   input             clk,
+   input             rst,
+   input             flush_i,  // flush pipe
+   input             adv_i,    // advance pipe
+   input             start_i,  // start conversion
+   input      [31:0] opa_i,
+   output reg        i2f_rdy_o,       // i2f is ready
+   output reg        i2f_sign_o,      // i2f signum
+   output reg  [3:0] i2f_shr_o,
+   output reg  [7:0] i2f_exp8shr_o,
+   output reg  [4:0] i2f_shl_o,
+   output reg  [7:0] i2f_exp8shl_o,
+   output reg  [7:0] i2f_exp8sh0_o,
+   output reg [31:0] i2f_fract32_o
+);
+
+  /*
+     Any stage's output is registered.
+     Definitions:
+       s??o_name - "S"tage number "??", "O"utput
+       s??t_name - "S"tage number "??", "T"emporary (internally)
+  */
+
+  // signum of input
+  wire s1t_signa = opa_i[31];
+  // magnitude (tow's complement for negative input)
+  wire [31:0] s1t_fract32 =
+      (opa_i ^ {32{s1t_signa}}) + {31'd0,s1t_signa};
+  // normalization shifts
+  reg [3:0] s1t_shrx;
+  reg [4:0] s1t_shlx;
+  // shift goal:
+  // 23 22                    0
+  // |  |                     |
+  // h  fffffffffffffffffffffff
+  // right shift
+  always @(s1t_fract32[31:24]) begin
+    casez(s1t_fract32[31:24])  // synopsys full_case parallel_case
+      8'b1???????:  s1t_shrx = 4'd8;
+      8'b01??????:  s1t_shrx = 4'd7;
+      8'b001?????:  s1t_shrx = 4'd6;
+      8'b0001????:  s1t_shrx = 4'd5;
+      8'b00001???:  s1t_shrx = 4'd4;
+      8'b000001??:  s1t_shrx = 4'd3;
+      8'b0000001?:  s1t_shrx = 4'd2;
+      8'b00000001:  s1t_shrx = 4'd1;
+      8'b00000000:  s1t_shrx = 4'd0;
+    endcase
+  end
+  // left shift
+  always @(s1t_fract32[23:0]) begin
+    casez(s1t_fract32[23:0])  // synopsys full_case parallel_case
+      24'b1???????????????????????:  s1t_shlx = 5'd0; // hidden '1' is in its plase
+      24'b01??????????????????????:  s1t_shlx = 5'd1;
+      24'b001?????????????????????:  s1t_shlx = 5'd2;
+      24'b0001????????????????????:  s1t_shlx = 5'd3;
+      24'b00001???????????????????:  s1t_shlx = 5'd4;
+      24'b000001??????????????????:  s1t_shlx = 5'd5;
+      24'b0000001?????????????????:  s1t_shlx = 5'd6;
+      24'b00000001????????????????:  s1t_shlx = 5'd7;
+      24'b000000001???????????????:  s1t_shlx = 5'd8;
+      24'b0000000001??????????????:  s1t_shlx = 5'd9;
+      24'b00000000001?????????????:  s1t_shlx = 5'd10;
+      24'b000000000001????????????:  s1t_shlx = 5'd11;
+      24'b0000000000001???????????:  s1t_shlx = 5'd12;
+      24'b00000000000001??????????:  s1t_shlx = 5'd13;
+      24'b000000000000001?????????:  s1t_shlx = 5'd14;
+      24'b0000000000000001????????:  s1t_shlx = 5'd15;
+      24'b00000000000000001???????:  s1t_shlx = 5'd16;
+      24'b000000000000000001??????:  s1t_shlx = 5'd17;
+      24'b0000000000000000001?????:  s1t_shlx = 5'd18;
+      24'b00000000000000000001????:  s1t_shlx = 5'd19;
+      24'b000000000000000000001???:  s1t_shlx = 5'd20;
+      24'b0000000000000000000001??:  s1t_shlx = 5'd21;
+      24'b00000000000000000000001?:  s1t_shlx = 5'd22;
+      24'b000000000000000000000001:  s1t_shlx = 5'd23;
+      24'b000000000000000000000000:  s1t_shlx = 5'd0;
+    endcase
+  end
+
+
+  // registering output
+  always @(posedge clk) begin
+    if(adv_i) begin
+        // computation related
+      i2f_sign_o    <= s1t_signa;
+      i2f_shr_o     <= s1t_shrx;
+      i2f_exp8shr_o <= 8'd150 + {4'd0,s1t_shrx};      // 150=127+23
+      i2f_shl_o     <= s1t_shlx;
+      i2f_exp8shl_o <= 8'd150 - {3'd0,s1t_shlx};
+      i2f_exp8sh0_o <= {8{s1t_fract32[23]}} & 8'd150; // "1" is in [23] / zero
+      i2f_fract32_o <= s1t_fract32;
+    end // advance
+  end // posedge clock
+
+  // ready is special case
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst)
+      i2f_rdy_o <= 1'b0;
+    else if(flush_i)
+      i2f_rdy_o <= 1'b0;
+    else if(adv_i)
+      i2f_rdy_o <= start_i;
+  end // posedge clock
+
+endmodule // pfpu32_i2f

--- a/rtl/verilog/pfpu32/pfpu32_muldiv.v
+++ b/rtl/verilog/pfpu32/pfpu32_muldiv.v
@@ -1,0 +1,807 @@
+//////////////////////////////////////////////////////////////////////
+//                                                                  //
+//    pfpu32_muldiv                                                 //
+//                                                                  //
+//    This file is part of the mor1kx project                       //
+//    https://github.com/openrisc/mor1kx                            //
+//                                                                  //
+//    Description                                                   //
+//    combined multiplier/divisor pipeline for                      //
+//    single precision floating point numbers                       //
+//                                                                  //
+//    Author(s):                                                    //
+//          Andrey Bacherov, avbacherov@opencores.org               //
+//                                                                  //
+//////////////////////////////////////////////////////////////////////
+//                                                                  //
+//  Copyright (C) 2015                                              //
+//                                                                  //
+//  This source file may be used and distributed without            //
+//  restriction provided that this copyright statement is not       //
+//  removed from the file and that any derivative work contains     //
+//  the original copyright notice and the associated disclaimer.    //
+//                                                                  //
+//    THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY           //
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED       //
+//  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS       //
+//  FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL THE AUTHOR          //
+//  OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,             //
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        //
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE       //
+//  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR            //
+//  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF      //
+//  LIABILITY, WHETHER IN  CONTRACT, STRICT LIABILITY, OR TORT      //
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT      //
+//  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE             //
+//  POSSIBILITY OF SUCH DAMAGE.                                     //
+//////////////////////////////////////////////////////////////////////
+
+`include "mor1kx-defines.v"
+
+module pfpu32_muldiv
+(
+   input             clk,
+   input             rst,
+   input             flush_i,  // flushe pipe
+   input             adv_i,    // advance pipe
+   input             start_i,  // start
+   input             is_div_i, // 1: division, 0: multiplication
+   // input 'a' related values
+   input             signa_i,
+   input       [9:0] exp10a_i,
+   input      [23:0] fract24a_i,
+   input             infa_i,
+   input             zeroa_i,
+   // input 'b' related values
+   input             signb_i,
+   input       [9:0] exp10b_i,
+   input      [23:0] fract24b_i,
+   input             infb_i,
+   input             zerob_i,
+   // 'a'/'b' related
+   input             snan_i,
+   input             qnan_i,
+   input             anan_sign_i,
+   // MUL/DIV common outputs
+   output reg        muldiv_rdy_o,       // ready
+   output reg        muldiv_sign_o,      // signum
+   output reg  [4:0] muldiv_shr_o,       // do right shift in align stage
+   output reg  [9:0] muldiv_exp10shr_o,  // exponent for right shift align
+   output reg        muldiv_shl_o,       // do left shift in align stage
+   output reg  [9:0] muldiv_exp10shl_o,  // exponent for left shift align
+   output reg  [9:0] muldiv_exp10sh0_o,  // exponent for no shift in align
+   output reg [27:0] muldiv_fract28_o,   // fractional with appended {r,s} bits
+   output reg        muldiv_inv_o,       // invalid operation flag
+   output reg        muldiv_inf_o,       // infinity output reg
+   output reg        muldiv_snan_o,      // signaling NaN output reg
+   output reg        muldiv_qnan_o,      // quiet NaN output reg
+   output reg        muldiv_anan_sign_o, // signum for output nan
+   // DIV additional outputs
+   output reg        div_op_o,           // operation is division
+   output reg        div_sign_rmnd_o,    // signum of reminder for IEEE compliant rounding
+   output reg        div_dbz_o           // div division by zero flag
+);
+
+  /*
+    !!! If an input is denormalized the additional 1-clk stage
+    !!!  (for normalization) is executed.
+    !!! But inputs must not change during the stage.
+
+     Any stage's output is registered.
+     Definitions:
+       s??o_name - "S"tage number "??", "O"utput
+       s??t_name - "S"tage number "??", "T"emporary (internally)
+  */
+
+
+  /* Stage #1: pre-operation stage */
+
+
+    // detection of some exceptions
+  wire s0t_inv = is_div_i ? ((zeroa_i & zerob_i) | (infa_i & infb_i)) : // div: 0/0, inf/inf -> invalid operation; snan output
+                            ((zeroa_i & infb_i) | (zerob_i & infa_i));  // mul: 0 * inf -> invalid operation; snan output
+    // division by zero
+  wire s0t_dbz   = is_div_i & (~zeroa_i) & (~infa_i) & zerob_i;
+    //   inf input
+  wire s0t_inf_i = infa_i | (infb_i & (~is_div_i)); // for DIV only infA is used
+
+    // force intermediate results to zero
+  wire s0t_opc_0 = zeroa_i | zerob_i | (is_div_i & (infa_i | infb_i));
+
+  // count leading zeros
+  reg [4:0] s0t_nlza;
+  always @(fract24a_i) begin
+    casez(fract24a_i) // synopsys full_case parallel_case
+      24'b1???????????????????????: s0t_nlza =  0;
+      24'b01??????????????????????: s0t_nlza =  1;
+      24'b001?????????????????????: s0t_nlza =  2;
+      24'b0001????????????????????: s0t_nlza =  3;
+      24'b00001???????????????????: s0t_nlza =  4;
+      24'b000001??????????????????: s0t_nlza =  5;
+      24'b0000001?????????????????: s0t_nlza =  6;
+      24'b00000001????????????????: s0t_nlza =  7;
+      24'b000000001???????????????: s0t_nlza =  8;
+      24'b0000000001??????????????: s0t_nlza =  9;
+      24'b00000000001?????????????: s0t_nlza = 10;
+      24'b000000000001????????????: s0t_nlza = 11;
+      24'b0000000000001???????????: s0t_nlza = 12;
+      24'b00000000000001??????????: s0t_nlza = 13;
+      24'b000000000000001?????????: s0t_nlza = 14;
+      24'b0000000000000001????????: s0t_nlza = 15;
+      24'b00000000000000001???????: s0t_nlza = 16;
+      24'b000000000000000001??????: s0t_nlza = 17;
+      24'b0000000000000000001?????: s0t_nlza = 18;
+      24'b00000000000000000001????: s0t_nlza = 19;
+      24'b000000000000000000001???: s0t_nlza = 20;
+      24'b0000000000000000000001??: s0t_nlza = 21;
+      24'b00000000000000000000001?: s0t_nlza = 22;
+      24'b000000000000000000000001: s0t_nlza = 23;
+      24'b000000000000000000000000: s0t_nlza =  0; // zero rezult
+    endcase
+  end // nlz for 'a'
+
+  // count leading zeros
+  reg [4:0] s0t_nlzb;
+  always @(fract24b_i) begin
+    casez(fract24b_i) // synopsys full_case parallel_case
+      24'b1???????????????????????: s0t_nlzb =  0;
+      24'b01??????????????????????: s0t_nlzb =  1;
+      24'b001?????????????????????: s0t_nlzb =  2;
+      24'b0001????????????????????: s0t_nlzb =  3;
+      24'b00001???????????????????: s0t_nlzb =  4;
+      24'b000001??????????????????: s0t_nlzb =  5;
+      24'b0000001?????????????????: s0t_nlzb =  6;
+      24'b00000001????????????????: s0t_nlzb =  7;
+      24'b000000001???????????????: s0t_nlzb =  8;
+      24'b0000000001??????????????: s0t_nlzb =  9;
+      24'b00000000001?????????????: s0t_nlzb = 10;
+      24'b000000000001????????????: s0t_nlzb = 11;
+      24'b0000000000001???????????: s0t_nlzb = 12;
+      24'b00000000000001??????????: s0t_nlzb = 13;
+      24'b000000000000001?????????: s0t_nlzb = 14;
+      24'b0000000000000001????????: s0t_nlzb = 15;
+      24'b00000000000000001???????: s0t_nlzb = 16;
+      24'b000000000000000001??????: s0t_nlzb = 17;
+      24'b0000000000000000001?????: s0t_nlzb = 18;
+      24'b00000000000000000001????: s0t_nlzb = 19;
+      24'b000000000000000000001???: s0t_nlzb = 20;
+      24'b0000000000000000000001??: s0t_nlzb = 21;
+      24'b00000000000000000000001?: s0t_nlzb = 22;
+      24'b000000000000000000000001: s0t_nlzb = 23;
+      24'b000000000000000000000000: s0t_nlzb =  0; // zero result
+    endcase
+  end // nlz of 'b'
+
+
+  // pre-norm stage outputs
+  //   input related
+  reg s0o_inv, s0o_inf_i,
+      s0o_snan_i, s0o_qnan_i, s0o_anan_i_sign;
+  //   computation related
+  reg        s0o_is_div;
+  reg        s0o_opc_0;
+  reg        s0o_signc;
+  reg  [9:0] s0o_exp10a;
+  reg [23:0] s0o_fract24a;
+  reg  [4:0] s0o_shla;
+  reg  [9:0] s0o_exp10b;
+  reg [23:0] s0o_fract24b;
+  reg  [4:0] s0o_shlb;
+  // DIV additional outputs
+  reg        s0o_dbz;
+  // registering
+  always @(posedge clk) begin
+    if(adv_i) begin
+        // input related
+      s0o_inv         <= s0t_inv;
+      s0o_inf_i       <= s0t_inf_i;
+      s0o_snan_i      <= snan_i;
+      s0o_qnan_i      <= qnan_i;
+      s0o_anan_i_sign <= anan_sign_i;
+        // computation related
+      s0o_is_div   <= is_div_i;
+      s0o_opc_0    <= s0t_opc_0;
+      s0o_signc    <= signa_i ^ signb_i;
+      s0o_exp10a   <= exp10a_i;
+      s0o_fract24a <= fract24a_i;
+      s0o_shla     <= s0t_nlza;
+      s0o_exp10b   <= exp10b_i;
+      s0o_fract24b <= fract24b_i;
+      s0o_shlb     <= s0t_nlzb;
+        // DIV additional outputs
+      s0o_dbz   <= s0t_dbz;
+    end // push pipe
+  end
+
+  // route ready through side back
+  reg s0o_ready;
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst)
+      s0o_ready <= 0;
+    else if(flush_i)
+      s0o_ready <= 0;
+    else if(adv_i)
+      s0o_ready <= start_i;
+  end // posedge clock
+
+
+  // left-shift the dividend and divisor
+  wire [23:0] s1t_fract24a_shl = s0o_fract24a << s0o_shla;
+  wire [23:0] s1t_fract24b_shl = s0o_fract24b << s0o_shlb;
+  
+  // force result to zero
+  wire [23:0] s1t_fract24a = s1t_fract24a_shl & {24{~s0o_opc_0}};
+  wire [23:0] s1t_fract24b = s1t_fract24b_shl & {24{~s0o_opc_0}};
+
+  // exponent
+  wire [9:0] s1t_exp10mux =
+    s0o_is_div ? (s0o_exp10a - {5'd0,s0o_shla} - s0o_exp10b + {5'd0,s0o_shlb} + 10'd127) :
+                 (s0o_exp10a - {5'd0,s0o_shla} + s0o_exp10b - {5'd0,s0o_shlb} - 10'd127);
+  
+  // force result to zero
+  wire [9:0] s1t_exp10c = s1t_exp10mux & {10{~s0o_opc_0}};
+
+
+  // Goldshmidt division iterations control
+  reg [10:0] itr_state; // iteration state indicator
+  // iteration characteristic points:
+  //   quotient is computed
+  wire itr_rndQ = itr_state[10];
+  // iteration control state machine
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst)
+      itr_state <= 11'd0;
+    else if(flush_i)
+      itr_state <= 11'd0;
+    else if(adv_i & s0o_ready & s0o_is_div)
+      itr_state <= 11'd1;
+    else if(adv_i)
+      itr_state <= {itr_state[9:0],1'b0};
+  end // posedge clock
+
+  // Multiplication operation flag
+  wire s1t_is_mul = s0o_ready & (~s0o_is_div);
+
+
+  // stage #1 outputs
+  //   input related
+  reg s1o_inv, s1o_inf_i,
+      s1o_snan_i, s1o_qnan_i, s1o_anan_i_sign;
+  //   computation related
+  reg        s1o_opc_0;
+  reg        s1o_signc;
+  reg [9:0]  s1o_exp10c;
+  reg [23:0] s1o_fract24a;
+  reg [23:0] s1o_fract24b;
+  // DIV additional outputs
+  reg        s1o_dbz;
+  //   registering
+  always @(posedge clk) begin
+    if(adv_i) begin
+        // input related
+      s1o_inv         <= s0o_inv;
+      s1o_inf_i       <= s0o_inf_i;
+      s1o_snan_i      <= s0o_snan_i;
+      s1o_qnan_i      <= s0o_qnan_i;
+      s1o_anan_i_sign <= s0o_anan_i_sign;
+        // computation related
+      s1o_opc_0    <= s0o_opc_0;
+      s1o_signc    <= s0o_signc;
+      s1o_exp10c   <= s1t_exp10c;
+      s1o_fract24a <= s1t_fract24a;
+      s1o_fract24b <= s1t_fract24b;
+        // DIV additional outputs
+      s1o_dbz <= s0o_dbz;
+    end // advance pipe
+  end // posedge clock
+
+  // ready is special case
+  reg s1o_mul_ready;
+  reg s1o_div_ready;
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst) begin
+      s1o_mul_ready <= 1'b0;
+      s1o_div_ready <= 1'b0;
+    end else if(flush_i) begin
+      s1o_mul_ready <= 1'b0;
+      s1o_div_ready <= 1'b0;
+    end else if(adv_i) begin
+      s1o_mul_ready <= s1t_is_mul;
+      s1o_div_ready <= itr_rndQ;
+    end
+  end // posedge clock
+
+
+  /* Stage #2: 1st part of multiplier */
+
+
+  // rigt shift value
+  // and appropriatelly corrected exponent
+  wire s1o_exp10c_0             = ~(|s1o_exp10c);
+  wire [9:0] s2t_shr_of_neg_exp = 11'h401 - {1'b0,s1o_exp10c}; // 1024-v+1
+  // variants:
+  wire [9:0] s2t_shr_t;
+  wire [9:0] s2t_exp10rx;
+  assign {s2t_shr_t,s2t_exp10rx} =
+    // force zero result
+    s1o_opc_0     ? {10'd0,10'd0} :
+    // negative exponent sum
+    //   (!) takes 1x.xx case into account automatically
+    s1o_exp10c[9] ? {s2t_shr_of_neg_exp,10'd1} :
+    // (a) zero exponent sum (denorm. result potentially)
+    //   (!) takes 1x.xx case into account automatically
+    // (b) normal case
+    //   (!) 1x.xx case is processed in next stage
+                    {{9'd0,s1o_exp10c_0},(s1o_exp10c | {9'd0,s1o_exp10c_0})};
+  // limited by 31 and forced result to zero
+  wire [4:0] s2t_shrx = s2t_shr_t[4:0] | {5{|s2t_shr_t[9:5]}};
+
+
+  // Support Goldshmidt iteration
+  // initial estimation of reciprocal
+  wire [8:0] itr_recip9b;
+  arecip_lut u_arlut
+  (
+    .b_i(s1o_fract24b[22:16]),
+    .r_o(itr_recip9b)
+  );
+  // support case: b==1
+  wire b_eq_1 = s1o_fract24b[23] & (~(|s1o_fract24b[22:0]));
+  // reciprocal with restored leading 01
+  wire [10:0] itr_recip11b = b_eq_1 ?  11'b10000000000 :
+                                      {2'b01,itr_recip9b};
+
+  // the subsequent two stages multiplier operates with 32-bit inputs
+  // 25-bits: fractionals (quotient is in range 0.5 to 1)
+  //  1-bit : rounding bit
+  //  6-bits: guard (due to truncations of intermediate results)
+
+  // intermediate results:
+  //   updated divisor (D) is rounded up while all other intermediate values
+  //   are just truncated in according with directed rounding analysed in:
+  //     Guy Even, Peter-M.Seidel, Warren E.Ferguson
+  //     "A parametric error analysis of Goldschmidt’s division algorithm"
+  wire itr_rndD = itr_state[3] | itr_state[6];
+  wire itr_rndDvsr;
+  //   align resulting quotient to support subsequent IEEE-compliant rounding
+  wire [25:0] itr_res_qtnt26; // rounded quotient
+  //   Updated quotient or divisor
+  wire [32:0] itr_qtnt33;
+  //   'F' (2-D) or 'Reminder'
+  wire [32:0] itr_rmnd33;
+
+
+  // control for multiplier's input 'A'
+  //   the register also contains quotient to output
+  wire itr_uinA = s1t_is_mul   |
+                  itr_state[0] | itr_state[3] | 
+                  itr_state[6] | itr_rndQ;
+  // multiplexer for multiplier's input 'A'
+  wire [31:0] itr_mul32a =
+     s1t_is_mul   ? {s1t_fract24a,8'd0}   :
+     itr_state[0] ? {itr_recip11b,21'd0}  :
+     itr_rndQ     ? {itr_res_qtnt26,6'd0} : // truncate by 2^(-n-1)
+                     itr_rmnd33[31:0];
+  // register of multiplier's input 'A'
+  reg [15:0] s1o_mul16_al;
+  reg [15:0] s1o_mul16_ah;
+  // registering
+  always @(posedge clk) begin
+    if(adv_i & itr_uinA) begin
+      s1o_mul16_al <= itr_mul32a[15: 0];
+      s1o_mul16_ah <= itr_mul32a[31:16];
+    end
+  end // posedge clock
+
+
+  // control for multiplier's input 'B'
+  wire itr_uinB = s1t_is_mul   |
+                  itr_state[0] | itr_state[1] |
+                  itr_state[3] | itr_state[4] |
+                  itr_state[6] | itr_state[7] |
+                  itr_rndQ;
+  // multiplexer for multiplier's input 'B'
+  wire [31:0] itr_mul32b =
+     s1t_is_mul               ? {s1t_fract24b,8'd0} :
+    (itr_state[0] | itr_rndQ) ? {s1o_fract24b,8'd0} :
+     itr_state[1]             ? {s1o_fract24a,8'd0} :
+                                 itr_qtnt33[31:0];
+  // register of multiplier's input 'B'
+  reg [15:0] s1o_mul16_bl;
+  reg [15:0] s1o_mul16_bh;
+  always @(posedge clk) begin
+    if(adv_i & itr_uinB) begin
+      s1o_mul16_bl <= itr_mul32b[15: 0];
+      s1o_mul16_bh <= itr_mul32b[31:16];
+    end
+  end // posedge clock
+
+  // stage #2 outputs
+  //   input related
+  reg s2o_inv, s2o_inf_i,
+      s2o_snan_i, s2o_qnan_i, s2o_anan_i_sign;
+  // DIV additional outputs
+  reg        s2o_dbz;
+  reg [23:0] s2o_fract24a;
+  //   computation related
+  reg        s2o_opc_0;
+  reg        s2o_signc;
+  reg  [9:0] s2o_exp10c;
+  reg  [4:0] s2o_shrx;
+  reg        s2o_is_shrx;
+  reg  [9:0] s2o_exp10rx;
+  //   multipliers
+  reg [31:0] s2o_fract32_albl;
+  reg [31:0] s2o_fract32_albh;
+  reg [31:0] s2o_fract32_ahbl;
+  reg [31:0] s2o_fract32_ahbh;
+  //   registering
+  always @(posedge clk) begin
+    if(adv_i) begin
+        // input related
+      s2o_inv         <= s1o_inv;
+      s2o_inf_i       <= s1o_inf_i;
+      s2o_snan_i      <= s1o_snan_i;
+      s2o_qnan_i      <= s1o_qnan_i;
+      s2o_anan_i_sign <= s1o_anan_i_sign;
+        // DIV additional outputs
+      s2o_dbz      <= s1o_dbz;
+      s2o_fract24a <= s1o_fract24a;
+        // computation related
+      s2o_opc_0   <= s1o_opc_0;
+      s2o_signc   <= s1o_signc;
+      s2o_exp10c  <= s1o_exp10c;
+      s2o_shrx    <= s2t_shrx;
+      s2o_is_shrx <= (|s2t_shrx);
+      s2o_exp10rx <= s2t_exp10rx;
+        // multipliers
+      s2o_fract32_albl <= s1o_mul16_al * s1o_mul16_bl;
+      s2o_fract32_albh <= s1o_mul16_al * s1o_mul16_bh;
+      s2o_fract32_ahbl <= s1o_mul16_ah * s1o_mul16_bl;
+      s2o_fract32_ahbh <= s1o_mul16_ah * s1o_mul16_bh;
+    end // advance pipe
+  end // posedge clock
+
+  // ready is special case
+  reg s2o_mul_ready;
+  reg s2o_div_ready;
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst) begin
+      s2o_mul_ready <= 1'b0;
+      s2o_div_ready <= 1'b0;
+    end else if(flush_i) begin
+      s2o_mul_ready <= 1'b0;
+      s2o_div_ready <= 1'b0;
+    end else if(adv_i) begin
+      s2o_mul_ready <= s1o_mul_ready;
+      s2o_div_ready <= s1o_div_ready;
+    end
+  end // posedge clock
+
+
+  /* Stage #3: 2nd part of multiplier */
+
+
+  // 2nd stage of multiplier
+  wire [47:0] s3t_fract48;
+  assign s3t_fract48 = {s2o_fract32_ahbh,  16'd0} +
+                       {16'd0, s2o_fract32_ahbl} +
+                       {16'd0, s2o_fract32_albh} +
+                       {32'd0, s2o_fract32_albl[31:16]};
+
+  // stage #3 outputs (for division support)
+  
+  // full product
+  reg [32:0] s3o_mul33o; // output
+  reg        s3o_mul33s; // sticky
+  //   registering
+  always @(posedge clk) begin
+    if(adv_i) begin
+      s3o_mul33o <= s3t_fract48[47:15];
+      s3o_mul33s <= (|s3t_fract48[14:0]) | (|s2o_fract32_albl[15:0]);
+    end
+  end // posedge clock
+
+  // For pipelinization of division final stage
+  //   input related
+  reg s3o_inv, s3o_inf_i,
+      s3o_snan_i, s3o_qnan_i, s3o_anan_i_sign;
+  //   DIV computation related
+  reg        s3o_dbz;
+  reg [23:0] s3o_fract24a;
+  reg        s3o_opc_0;
+  reg        s3o_signc;
+  reg  [9:0] s3o_exp10c;
+  reg  [4:0] s3o_shrx;
+  reg        s3o_is_shrx;
+  reg  [9:0] s3o_exp10rx;
+  // registering
+  always @(posedge clk) begin
+    if(adv_i) begin
+        // input related
+      s3o_inv         <= s2o_inv;
+      s3o_inf_i       <= s2o_inf_i;
+      s3o_snan_i      <= s2o_snan_i;
+      s3o_qnan_i      <= s2o_qnan_i;
+      s3o_anan_i_sign <= s2o_anan_i_sign;
+        // DIV computation related
+      s3o_dbz      <= s2o_dbz;
+      s3o_fract24a <= s2o_fract24a;
+      s3o_opc_0    <= s2o_opc_0;
+      s3o_signc    <= s2o_signc;
+      s3o_exp10c   <= s2o_exp10c;
+      s3o_shrx     <= s2o_shrx;
+      s3o_is_shrx  <= s2o_is_shrx;
+      s3o_exp10rx  <= s2o_exp10rx;
+    end // advance pipe
+  end // @clock
+  
+  // stage 3 ready makes sense for division only
+  reg s3o_div_ready;
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst)
+      s3o_div_ready <= 1'b0;
+    else if(flush_i)
+      s3o_div_ready <= 1'b0;
+    else if(adv_i)
+      s3o_div_ready <= s2o_div_ready;
+  end // posedge clock
+
+
+  // Feedback from multiplier's output with various rounding tecqs.
+  //   +2^(-n-2) in case of rounding 1.xxx qutient
+  wire itr_rndQ1xx =   s3o_mul33o[31];
+  //   +2^(-n-2) in case of rounding 0.1xx qutient
+  wire itr_rndQ01x = (~s3o_mul33o[31]);
+  //   rounding mask:
+  wire [32:0] itr_rndM33 = // bits [6],[5] ... [0]
+    { 26'd0,(itr_rndQ & itr_rndQ1xx),(itr_rndQ & itr_rndQ01x), // round resulting quotient
+       4'd0,(itr_rndD & s3o_mul33s) };                         // round intermediate divisor
+  //   rounding
+  assign itr_qtnt33 = s3o_mul33o + itr_rndM33;
+
+
+  // compute 2's complement or reminder (for sticky bit detection)
+  // binary point position is located just after bit [30]
+  wire [32:0] itr_AorT33 =
+    s3o_div_ready ? {1'b0,s3o_fract24a,8'd0} : // for reminder
+                    {32'h80000000,1'b0};       // for two's complement
+
+  // 'Reminder' / Two's complement
+  assign itr_rmnd33 = itr_AorT33 - itr_qtnt33;
+
+  // Auxiliary flags:
+  //  - truncated reminder isn't zero
+  wire s4t_rmnd33_n0  = |itr_rmnd33;
+  //  - rounded quotient is exact
+  wire s4t_qtnt_exact = ~(s4t_rmnd33_n0 | s3o_mul33s);
+  //  - signum of final reminder
+  wire s4t_sign_rmnd  = itr_rmnd33[32] | ((~s4t_rmnd33_n0) & s3o_mul33s);
+
+
+  // Additionally store 26-bit of non-rounded (_raw_) and rounded (_res_) quotients.
+  // It is used for rounding in cases of denormalized result.
+  // Stiky bit is forced to be zero.
+  // The value are marked by stage #2 output
+  // raw
+  reg [25:0] s3o_raw_qtnt26;
+  // rounded
+  reg [25:0] s3o_res_qtnt26;
+  assign     itr_res_qtnt26 = {itr_qtnt33[31:7],itr_qtnt33[6] & itr_rndQ01x};
+  // latching
+  always @(posedge clk ) begin
+    if(itr_rndQ) begin
+      s3o_raw_qtnt26 <= s3o_mul33o[31:6];
+      s3o_res_qtnt26 <= itr_res_qtnt26;
+    end
+  end
+  
+  // Possible left shift computation.
+  // In fact, as the dividend and divisor was normalized
+  //   and the result is non-zero
+  //   the '1' is maximum number of leading zeros in the quotient.
+  wire s4t_nlz = ~s3o_res_qtnt26[25];
+  wire [9:0] s4t_exp10_m1 = s3o_exp10c - 10'd1;
+  // left shift flag and corrected exponent
+  wire       s4t_shlx;
+  wire [9:0] s4t_exp10lx;
+  assign {s4t_shlx,s4t_exp10lx} =
+      // shift isn't needed (includes zero result)
+    (~s4t_nlz)            ? {1'b0,s3o_exp10c} :
+      // normalization is possible
+    (s3o_exp10c >  10'd1) ? {1'b1,s4t_exp10_m1} :
+      // denormalized and zero cases
+                            {1'b0,{9'd0,~s3o_opc_0}};
+
+  // check if quotient is denormalized
+  wire s4t_denorm = s3o_is_shrx |
+                    ((~s3o_is_shrx) & (~s4t_shlx) & s4t_nlz);
+  // Select quotient for subsequent align and rounding
+  // The rounded (_res_) quotient is used:
+  //   - for normalized result
+  //   - exact result
+  //   - non-exact but lesser than infinity precision result
+  wire [25:0] s4t_qtnt26 =
+    ( (~s4t_denorm) | s4t_qtnt_exact |
+      ((~s4t_qtnt_exact) & (~s4t_sign_rmnd)) ) ? s3o_res_qtnt26 :
+                                                 s3o_raw_qtnt26;
+
+
+  // output
+  always @(posedge clk) begin
+    if(adv_i) begin
+        // input related
+      muldiv_inv_o       <= s3o_div_ready ? s3o_inv : s2o_inv;
+      muldiv_inf_o       <= s3o_div_ready ? s3o_inf_i : s2o_inf_i;
+      muldiv_snan_o      <= s3o_div_ready ? s3o_snan_i : s2o_snan_i;
+      muldiv_qnan_o      <= s3o_div_ready ? s3o_qnan_i : s2o_qnan_i;
+      muldiv_anan_sign_o <= s3o_div_ready ? s3o_anan_i_sign : s2o_anan_i_sign;
+        // computation related
+      muldiv_sign_o     <= s3o_div_ready ? s3o_signc : s2o_signc;
+      muldiv_shr_o      <= s3o_div_ready ? s3o_shrx : s2o_shrx;
+      muldiv_exp10shr_o <= s3o_div_ready ? s3o_exp10rx : s2o_exp10rx;
+      muldiv_shl_o      <= s3o_div_ready & s4t_shlx;          // makes sense for DIV only
+      muldiv_exp10shl_o <= {10{s3o_div_ready}} & s4t_exp10lx; // makes sense for DIV only
+      muldiv_exp10sh0_o <= s3o_div_ready ? s3o_exp10c : s2o_exp10c;
+      muldiv_fract28_o  <= s3o_div_ready ?
+                           {1'b0,s4t_qtnt26,~s4t_qtnt_exact} :      // quotient
+                           {s3t_fract48[47:21],|s3t_fract48[20:0]}; // product
+        // DIV additional outputs
+      div_op_o        <= s3o_div_ready;
+      div_sign_rmnd_o <= s3o_div_ready & s4t_sign_rmnd;
+      div_dbz_o       <= s3o_div_ready & s3o_dbz;
+    end // advance pipe
+  end // posedge clock
+
+  // ready is special case
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst)
+      muldiv_rdy_o <= 0;
+    else if(flush_i)
+      muldiv_rdy_o <= 0;
+    else if(adv_i)
+      muldiv_rdy_o <= s2o_mul_ready | s3o_div_ready;
+  end // posedge clock
+
+endmodule // pfpu32_muldiv
+
+
+// initial reciprocal approximation
+module arecip_lut
+(
+  input      [6:0] b_i,
+  output reg [8:0] r_o
+);
+  always @(b_i) begin
+    case(b_i) // synopsys full_case parallel_case
+      7'd0   : r_o = 9'd508;
+      7'd1   : r_o = 9'd500;
+      7'd2   : r_o = 9'd492;
+      7'd3   : r_o = 9'd485;
+      7'd4   : r_o = 9'd477;
+      7'd5   : r_o = 9'd470;
+      7'd6   : r_o = 9'd463;
+      7'd7   : r_o = 9'd455;
+      7'd8   : r_o = 9'd448;
+      7'd9   : r_o = 9'd441;
+      7'd10  : r_o = 9'd434;
+      7'd11  : r_o = 9'd428;
+      7'd12  : r_o = 9'd421;
+      7'd13  : r_o = 9'd414;
+      7'd14  : r_o = 9'd408;
+      7'd15  : r_o = 9'd401;
+      7'd16  : r_o = 9'd395;
+      7'd17  : r_o = 9'd389;
+      7'd18  : r_o = 9'd383;
+      7'd19  : r_o = 9'd377;
+      7'd20  : r_o = 9'd371;
+      7'd21  : r_o = 9'd365;
+      7'd22  : r_o = 9'd359;
+      7'd23  : r_o = 9'd353;
+      7'd24  : r_o = 9'd347;
+      7'd25  : r_o = 9'd342;
+      7'd26  : r_o = 9'd336;
+      7'd27  : r_o = 9'd331;
+      7'd28  : r_o = 9'd326;
+      7'd29  : r_o = 9'd320;
+      7'd30  : r_o = 9'd315;
+      7'd31  : r_o = 9'd310;
+      7'd32  : r_o = 9'd305;
+      7'd33  : r_o = 9'd300;
+      7'd34  : r_o = 9'd295;
+      7'd35  : r_o = 9'd290;
+      7'd36  : r_o = 9'd285;
+      7'd37  : r_o = 9'd280;
+      7'd38  : r_o = 9'd275;
+      7'd39  : r_o = 9'd271;
+      7'd40  : r_o = 9'd266;
+      7'd41  : r_o = 9'd261;
+      7'd42  : r_o = 9'd257;
+      7'd43  : r_o = 9'd252;
+      7'd44  : r_o = 9'd248;
+      7'd45  : r_o = 9'd243;
+      7'd46  : r_o = 9'd239;
+      7'd47  : r_o = 9'd235;
+      7'd48  : r_o = 9'd231;
+      7'd49  : r_o = 9'd226;
+      7'd50  : r_o = 9'd222;
+      7'd51  : r_o = 9'd218;
+      7'd52  : r_o = 9'd214;
+      7'd53  : r_o = 9'd210;
+      7'd54  : r_o = 9'd206;
+      7'd55  : r_o = 9'd202;
+      7'd56  : r_o = 9'd198;
+      7'd57  : r_o = 9'd195;
+      7'd58  : r_o = 9'd191;
+      7'd59  : r_o = 9'd187;
+      7'd60  : r_o = 9'd183;
+      7'd61  : r_o = 9'd180;
+      7'd62  : r_o = 9'd176;
+      7'd63  : r_o = 9'd172;
+      7'd64  : r_o = 9'd169;
+      7'd65  : r_o = 9'd165;
+      7'd66  : r_o = 9'd162;
+      7'd67  : r_o = 9'd158;
+      7'd68  : r_o = 9'd155;
+      7'd69  : r_o = 9'd152;
+      7'd70  : r_o = 9'd148;
+      7'd71  : r_o = 9'd145;
+      7'd72  : r_o = 9'd142;
+      7'd73  : r_o = 9'd138;
+      7'd74  : r_o = 9'd135;
+      7'd75  : r_o = 9'd132;
+      7'd76  : r_o = 9'd129;
+      7'd77  : r_o = 9'd126;
+      7'd78  : r_o = 9'd123;
+      7'd79  : r_o = 9'd120;
+      7'd80  : r_o = 9'd117;
+      7'd81  : r_o = 9'd114;
+      7'd82  : r_o = 9'd111;
+      7'd83  : r_o = 9'd108;
+      7'd84  : r_o = 9'd105;
+      7'd85  : r_o = 9'd102;
+      7'd86  : r_o = 9'd99;
+      7'd87  : r_o = 9'd96;
+      7'd88  : r_o = 9'd93;
+      7'd89  : r_o = 9'd91;
+      7'd90  : r_o = 9'd88;
+      7'd91  : r_o = 9'd85;
+      7'd92  : r_o = 9'd82;
+      7'd93  : r_o = 9'd80;
+      7'd94  : r_o = 9'd77;
+      7'd95  : r_o = 9'd74;
+      7'd96  : r_o = 9'd72;
+      7'd97  : r_o = 9'd69;
+      7'd98  : r_o = 9'd67;
+      7'd99  : r_o = 9'd64;
+      7'd100 : r_o = 9'd62;
+      7'd101 : r_o = 9'd59;
+      7'd102 : r_o = 9'd57;
+      7'd103 : r_o = 9'd54;
+      7'd104 : r_o = 9'd52;
+      7'd105 : r_o = 9'd49;
+      7'd106 : r_o = 9'd47;
+      7'd107 : r_o = 9'd45;
+      7'd108 : r_o = 9'd42;
+      7'd109 : r_o = 9'd40;
+      7'd110 : r_o = 9'd38;
+      7'd111 : r_o = 9'd35;
+      7'd112 : r_o = 9'd33;
+      7'd113 : r_o = 9'd31;
+      7'd114 : r_o = 9'd29;
+      7'd115 : r_o = 9'd26;
+      7'd116 : r_o = 9'd24;
+      7'd117 : r_o = 9'd22;
+      7'd118 : r_o = 9'd20;
+      7'd119 : r_o = 9'd18;
+      7'd120 : r_o = 9'd15;
+      7'd121 : r_o = 9'd13;
+      7'd122 : r_o = 9'd11;
+      7'd123 : r_o = 9'd9;
+      7'd124 : r_o = 9'd7;
+      7'd125 : r_o = 9'd5;
+      7'd126 : r_o = 9'd3;
+      default: r_o = 9'd1;
+    endcase // LUT for initial approximation of reciprocal
+  end // always
+endmodule

--- a/rtl/verilog/pfpu32/pfpu32_rnd.v
+++ b/rtl/verilog/pfpu32/pfpu32_rnd.v
@@ -1,0 +1,420 @@
+/////////////////////////////////////////////////////////////////////
+//                                                                 //
+//    pfpu32_rnd                                                   //
+//    32-bit common rounding module for FPU                        //
+//                                                                 //
+//    This file is part of the mor1kx project                      //
+//    https://github.com/openrisc/mor1kx                           //
+//                                                                 //
+//    Author: Andrey Bacherov                                      //
+//            avbacherov@opencores.org                             //
+//                                                                 //
+/////////////////////////////////////////////////////////////////////
+//                                                                 //
+//   Copyright (C) 2014 Andrey Bacherov                            //
+//                      avbacherov@opencores.org                   //
+//                                                                 //
+//   This source file may be used and distributed without          //
+//   restriction provided that this copyright statement is not     //
+//   removed from the file and that any derivative work contains   //
+//   the original copyright notice and the associated disclaimer.  //
+//                                                                 //
+//       THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY       //
+//   EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED     //
+//   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS     //
+//   FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL THE AUTHOR        //
+//   OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,           //
+//   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES      //
+//   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE     //
+//   GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR          //
+//   BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    //
+//   LIABILITY, WHETHER IN  CONTRACT, STRICT LIABILITY, OR TORT    //
+//   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT    //
+//   OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE           //
+//   POSSIBILITY OF SUCH DAMAGE.                                   //
+//                                                                 //
+/////////////////////////////////////////////////////////////////////
+
+`include "mor1kx-defines.v"
+
+module pfpu32_rnd
+(
+  // clocks, resets and other controls
+  input        clk,
+  input        rst,
+  input        flush_i,  // flush pipe
+  input        adv_i,    // advance pipe
+  input  [1:0] rmode_i,  // rounding mode
+  // input from add/sub
+  input        add_rdy_i,       // add/sub is ready
+  input        add_sign_i,      // add/sub signum
+  input        add_sub_0_i,     // flag that actual substruction is performed and result is zero
+  input  [4:0] add_shl_i,       // do left shift in align stage
+  input  [9:0] add_exp10shl_i,  // exponent for left shift align
+  input  [9:0] add_exp10sh0_i,  // exponent for no shift in align
+  input [27:0] add_fract28_i,   // fractional with appended {r,s} bits
+  input        add_inv_i,       // add/sub invalid operation flag
+  input        add_inf_i,       // add/sub infinity input
+  input        add_snan_i,      // add/sub signaling NaN input
+  input        add_qnan_i,      // add/sub quiet NaN input
+  input        add_anan_sign_i, // add/sub signum for output nan
+  // input from mul
+  input        mul_rdy_i,       // mul is ready
+  input        mul_sign_i,      // mul signum
+  input  [4:0] mul_shr_i,       // do right shift in align stage
+  input  [9:0] mul_exp10shr_i,  // exponent for right shift align
+  input        mul_shl_i,       // do left shift in align stage
+  input  [9:0] mul_exp10shl_i,  // exponent for left shift align
+  input  [9:0] mul_exp10sh0_i,  // exponent for no shift in align
+  input [27:0] mul_fract28_i,   // fractional with appended {r,s} bits
+  input        mul_inv_i,       // mul invalid operation flag
+  input        mul_inf_i,       // mul infinity input
+  input        mul_snan_i,      // mul signaling NaN input
+  input        mul_qnan_i,      // mul quiet NaN input
+  input        mul_anan_sign_i, // mul signum for output nan
+  // input from div
+  input        div_op_i,        // MUL/DIV output is division
+  input        div_sign_rmnd_i, // signum or reminder for IEEE compliant rounding
+  input        div_dbz_i,       // division by zero flag
+  // input from i2f
+  input        i2f_rdy_i,       // i2f is ready
+  input        i2f_sign_i,      // i2f signum
+  input  [3:0] i2f_shr_i,
+  input  [7:0] i2f_exp8shr_i,
+  input  [4:0] i2f_shl_i,
+  input  [7:0] i2f_exp8shl_i,
+  input  [7:0] i2f_exp8sh0_i,
+  input [31:0] i2f_fract32_i,   
+  // input from f2i
+  input        f2i_rdy_i,       // f2i is ready
+  input        f2i_sign_i,      // f2i signum
+  input [23:0] f2i_int24_i,     // f2i fractional
+  input  [4:0] f2i_shr_i,       // f2i required shift right value
+  input  [3:0] f2i_shl_i,       // f2i required shift left value   
+  input        f2i_ovf_i,       // f2i overflow flag
+  input        f2i_snan_i,      // f2i signaling NaN input
+  // input from cmp
+  input        cmp_rdy_i,       // cmp is ready
+  input        cmp_res_i,       // cmp result
+  input        cmp_inv_i,       // cmp invalid flag
+  input        cmp_inf_i,       // cmp infinity flag
+  // outputs
+  //  arithmetic part's outputs
+  output reg                  [31:0] fpu_result_o,
+  output reg                         fpu_arith_valid_o,
+  //  comparator's outputs 
+  output reg                         fpu_cmp_flag_o,
+  output reg                         fpu_cmp_valid_o,
+  //  common output
+  output reg [`OR1K_FPCSR_WIDTH-1:0] fpcsr_o
+);
+
+  localparam INF  = 31'b1111111100000000000000000000000;
+  localparam QNAN = 31'b1111111110000000000000000000000;
+  localparam SNAN = 31'b1111111101111111111111111111111;
+
+  // rounding mode isn't require pipelinization
+  wire rm_nearest = (rmode_i==2'b00);
+  wire rm_to_zero = (rmode_i==2'b01);
+  wire rm_to_infp = (rmode_i==2'b10);
+  wire rm_to_infm = (rmode_i==2'b11);
+
+  /*
+     Any stage's output is registered.
+     Definitions:
+       s??o_name - "S"tage number "??", "O"utput
+       s??t_name - "S"tage number "??", "T"emporary (internally)
+  */
+
+  /* Stage #1: common align */
+
+  wire        s1t_sign;
+  wire [34:0] s1t_fract35;
+  wire        s1t_inv;
+  wire        s1t_inf;
+  wire        s1t_snan;
+  wire        s1t_qnan;
+  wire        s1t_anan_sign;
+  wire  [4:0] s1t_shr;
+  wire  [4:0] s1t_shl;
+
+  // multiplexer for signums and flags
+  wire s1t_add_sign = add_sub_0_i ? rm_to_infm : add_sign_i;
+
+  assign {s1t_sign,s1t_inv,s1t_inf,s1t_snan,s1t_qnan,s1t_anan_sign} =
+    ({6{add_rdy_i}} & {s1t_add_sign,add_inv_i,add_inf_i,add_snan_i,add_qnan_i,add_anan_sign_i}) |
+    ({6{mul_rdy_i}} & {mul_sign_i,mul_inv_i,mul_inf_i,mul_snan_i,mul_qnan_i,mul_anan_sign_i}) |
+    ({6{f2i_rdy_i}} & {f2i_sign_i,1'b0,1'b0,f2i_snan_i,1'b0,f2i_sign_i}) |
+    ({6{i2f_rdy_i}} & {i2f_sign_i,1'b0,1'b0,1'b0,1'b0,1'b0});
+
+  // multiplexer for fractionals
+  assign s1t_fract35 =
+    ({35{add_rdy_i}} & {7'd0, add_fract28_i}) |
+    ({35{mul_rdy_i}} & {7'd0, mul_fract28_i}) |
+    ({35{f2i_rdy_i}} & {8'd0, f2i_int24_i, 3'd0}) |
+    ({35{i2f_rdy_i}} & {i2f_fract32_i,3'd0});
+
+  // overflow bit for add/mul
+  wire s1t_addmul_carry = (add_rdy_i & add_fract28_i[27]) |
+                          (mul_rdy_i & mul_fract28_i[27]);
+
+  // multiplexer for shift values
+  wire [4:0] s1t_shr_t;
+  assign {s1t_shr_t, s1t_shl} =
+    ({10{add_rdy_i}} & {5'd0, add_shl_i}) |
+    ({10{mul_rdy_i}} & {mul_shr_i, {4'd0,mul_shl_i}}) |
+    ({10{f2i_rdy_i}} & {f2i_shr_i, {1'b0,f2i_shl_i}}) |
+    ({10{i2f_rdy_i}} & {{1'b0,i2f_shr_i}, i2f_shl_i});
+
+  assign s1t_shr = (|s1t_shr_t) ? s1t_shr_t : {4'd0,s1t_addmul_carry};
+ 
+  // align
+  wire [34:0] s1t_fract35sh =
+    (|s1t_shr) ? (s1t_fract35 >> s1t_shr) :
+                 (s1t_fract35 << s1t_shl);
+
+  // update sticky bit for right shift case.
+  // maximum right shift value is :
+  //    27 for mul/div
+  //     8 for i2f
+  reg s1r_sticky;
+  always @(s1t_fract35 or s1t_shr) begin
+    case (s1t_shr)
+      5'd0   : s1r_sticky = |s1t_fract35[ 1:0];
+      5'd1   : s1r_sticky = |s1t_fract35[ 2:0];
+      5'd2   : s1r_sticky = |s1t_fract35[ 3:0];
+      5'd3   : s1r_sticky = |s1t_fract35[ 4:0];
+      5'd4   : s1r_sticky = |s1t_fract35[ 5:0];
+      5'd5   : s1r_sticky = |s1t_fract35[ 6:0];
+      5'd6   : s1r_sticky = |s1t_fract35[ 7:0];
+      5'd7   : s1r_sticky = |s1t_fract35[ 8:0];
+      5'd8   : s1r_sticky = |s1t_fract35[ 9:0];
+      5'd9   : s1r_sticky = |s1t_fract35[10:0];
+      5'd10  : s1r_sticky = |s1t_fract35[11:0];
+      5'd11  : s1r_sticky = |s1t_fract35[12:0];
+      5'd12  : s1r_sticky = |s1t_fract35[13:0];
+      5'd13  : s1r_sticky = |s1t_fract35[14:0];
+      5'd14  : s1r_sticky = |s1t_fract35[15:0];
+      5'd15  : s1r_sticky = |s1t_fract35[16:0];
+      5'd16  : s1r_sticky = |s1t_fract35[17:0];
+      5'd17  : s1r_sticky = |s1t_fract35[18:0];
+      5'd18  : s1r_sticky = |s1t_fract35[19:0];
+      5'd19  : s1r_sticky = |s1t_fract35[20:0];
+      5'd20  : s1r_sticky = |s1t_fract35[21:0];
+      5'd21  : s1r_sticky = |s1t_fract35[22:0];
+      5'd22  : s1r_sticky = |s1t_fract35[23:0];
+      5'd23  : s1r_sticky = |s1t_fract35[24:0];
+      5'd24  : s1r_sticky = |s1t_fract35[25:0];
+      5'd25  : s1r_sticky = |s1t_fract35[26:0];
+      default: s1r_sticky = |s1t_fract35[27:0];
+    endcase
+  end // always
+
+  // update sticky bit for left shift case.
+  reg s1l_sticky;
+  always @(s1t_fract35 or s1t_shl) begin
+    case (s1t_shl)
+      5'd0   : s1l_sticky = |s1t_fract35[1:0];
+      5'd1   : s1l_sticky =  s1t_fract35[0];
+      default: s1l_sticky = 1'b0;
+    endcase
+  end // always
+
+  wire s1t_sticky = (|s1t_shr) ? s1r_sticky : s1l_sticky;
+
+  // two stage multiplexer for exponents
+  wire [9:0] s1t_exp10shr;
+  wire [9:0] s1t_exp10shl;
+  wire [9:0] s1t_exp10sh0;
+  assign {s1t_exp10shr, s1t_exp10shl, s1t_exp10sh0} =
+    ({30{add_rdy_i}} & {add_exp10sh0_i, add_exp10shl_i, add_exp10sh0_i}) |
+    ({30{mul_rdy_i}} & {mul_exp10shr_i, mul_exp10shl_i, mul_exp10sh0_i}) |
+    ({30{f2i_rdy_i}} & {10'd0, 10'd0, 10'd0}) |
+    ({30{i2f_rdy_i}} & {{2'd0,i2f_exp8shr_i},{2'd0,i2f_exp8shl_i},{2'd0,i2f_exp8sh0_i}});
+
+  wire [9:0] s1t_exp10 =
+    (|s1t_shr_t)  ? s1t_exp10shr :
+    (~(|s1t_shl)) ? (s1t_exp10sh0 + {9'd0,s1t_addmul_carry}) :
+                    s1t_exp10shl;
+
+  // output of align stage 
+  reg        s1o_sign;
+  reg  [9:0] s1o_exp10;
+  reg [31:0] s1o_fract32;
+  reg  [1:0] s1o_rs;
+  reg        s1o_inv;
+  reg        s1o_inf;
+  reg        s1o_snan_i;
+  reg        s1o_qnan_i;
+  reg        s1o_anan_sign_i;
+  reg        s1o_div_op, s1o_div_sign_rmnd, s1o_div_dbz;
+  reg        s1o_f2i_ovf, s1o_f2i;
+  // registering
+  always @(posedge clk) begin
+    if(adv_i) begin
+      s1o_sign    <= s1t_sign;
+      s1o_exp10   <= s1t_exp10;
+      s1o_fract32 <= s1t_fract35sh[34:3];
+      s1o_rs      <= {s1t_fract35sh[2],s1t_sticky};
+      // various flags:
+      s1o_inv         <= s1t_inv;
+      s1o_inf         <= s1t_inf;
+      s1o_snan_i      <= s1t_snan;
+      s1o_qnan_i      <= s1t_qnan;
+      s1o_anan_sign_i <= s1t_anan_sign;
+      // DIV specials
+      s1o_div_op        <= mul_rdy_i & div_op_i;
+      s1o_div_sign_rmnd <= div_sign_rmnd_i;
+      s1o_div_dbz       <= div_dbz_i;
+      // I2F specials
+      s1o_f2i_ovf <= f2i_ovf_i;
+      s1o_f2i     <= f2i_rdy_i;
+    end // advance
+  end // posedge clock
+
+  // ready is special case
+  reg s1o_ready;
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst)
+      s1o_ready <= 1'b0;
+    else if(flush_i)
+      s1o_ready <= 1'b0;
+    else if(adv_i)
+      s1o_ready <= (add_rdy_i | mul_rdy_i | f2i_rdy_i | i2f_rdy_i);
+  end // posedge clock
+
+
+  /* Stage #2: rounding */
+
+
+  wire s2t_dbz  = s1o_div_dbz;
+
+  wire s2t_g    = s1o_fract32[0];
+  wire s2t_r    = s1o_rs[1];
+  wire s2t_s    = s1o_rs[0];
+  wire s2t_lost = s2t_r | s2t_s;
+
+  wire s2t_rnd_up = (rm_nearest & s2t_r & s2t_s) |
+                    (rm_nearest & s2t_g & s2t_r & (~s2t_s)) |
+                    (rm_to_infp & (~s1o_sign) & s2t_lost) |
+                    (rm_to_infm &   s1o_sign  & s2t_lost);
+
+  // IEEE compliance rounding for qutient
+  wire s2t_div_rnd_up =
+    (rm_nearest & s2t_r & s2t_s & (~s1o_div_sign_rmnd)) |
+    ( ((rm_to_infp & (~s1o_sign)) | (rm_to_infm & s1o_sign)) &
+      ((s2t_r & s2t_s) | ((~s2t_r) & s2t_s & (~s1o_div_sign_rmnd))) );
+  wire s2t_div_rnd_dn = (~s2t_r) & s2t_s & s1o_div_sign_rmnd &
+    ( (rm_to_infp &   s1o_sign)  |
+      (rm_to_infm & (~s1o_sign)) |
+       rm_to_zero );
+
+  // set resulting direction of rounding
+  //  a) normalized quotient is rounded by quotient related rules
+  //  b) de-normalized quotient is rounded by common rules
+  wire s2t_rnd_n_qtnt = s1o_div_op & s1o_fract32[23]; // normalized quotient
+  wire s2t_set_rnd_up = s2t_rnd_n_qtnt ? s2t_div_rnd_up : s2t_rnd_up;
+  wire s2t_set_rnd_dn = s2t_rnd_n_qtnt ? s2t_div_rnd_dn : 1'b0;
+
+  // define value for rounding adder
+  wire [31:0] s2t_rnd_v32 =
+    s2t_set_rnd_up ? 32'd1        : // +1
+    s2t_set_rnd_dn ? 32'hFFFFFFFF : // -1
+                     32'd0;         // no rounding
+  // rounded fractional
+  wire [31:0] s2t_fract32_rnd = s1o_fract32 + s2t_rnd_v32;
+
+
+  // floating point output
+  wire s2t_f32_shr = s2t_fract32_rnd[24];
+  // update exponent and fraction
+  wire [9:0]  s2t_f32_exp10   = s1o_exp10 + {9'd0,s2t_f32_shr};
+  wire [23:0] s2t_f32_fract24 = s2t_f32_shr ? s2t_fract32_rnd[24:1] :
+                                              s2t_fract32_rnd[23:0];
+   // denormalized or zero
+  wire s2t_f32_fract24_dn = ~s2t_f32_fract24[23];
+
+
+  // integer output (f2i)
+  wire s2t_i32_carry_rnd = s2t_fract32_rnd[31];
+  wire s2t_i32_inv = ((~s1o_sign) & s2t_i32_carry_rnd) | s1o_f2i_ovf;
+  // two's complement for negative number
+  wire [31:0] s2t_i32_int32 = (s2t_fract32_rnd ^ {32{s1o_sign}}) + {31'd0,s1o_sign};
+  // zero
+  wire s2t_i32_int32_00 = (~s2t_i32_inv) & (~(|s2t_i32_int32));
+  // int32 output
+  wire [31:0] s2t_i32_opc;
+  assign s2t_i32_opc =
+    s2t_i32_inv ? (32'h7fffffff ^ {32{s1o_sign}}) : s2t_i32_int32;
+
+
+   // Generate result and flags
+  wire s2t_ine, s2t_ovf, s2t_inf, s2t_unf, s2t_zer;
+  wire [31:0] s2t_opc;
+  assign {s2t_opc,s2t_ine,s2t_ovf,s2t_inf,s2t_unf,s2t_zer} =
+    // f2i
+    s1o_f2i ?       //  ine  ovf  inf  unf              zer
+      {s2t_i32_opc,s2t_lost,1'b0,1'b0,1'b0,s2t_i32_int32_00} :
+    // qnan output
+    (s1o_snan_i | s1o_qnan_i) ? // ine  ovf  inf  unf  zer
+      {{s1o_anan_sign_i,QNAN},    1'b0,1'b0,1'b0,1'b0,1'b0} :
+    // snan output
+    s1o_inv ?        // ine  ovf  inf  unf  zer
+      {{s1o_sign,SNAN},1'b0,1'b0,1'b0,1'b0,1'b0} :
+    // overflow and infinity
+    ((s2t_f32_exp10 > 10'd254) | s1o_inf | s2t_dbz) ? // ine                       ovf  inf  unf  zer
+      {{s1o_sign,INF},((s2t_lost | (~s1o_inf)) & (~s2t_dbz)),((~s1o_inf) & (~s2t_dbz)),1'b1,1'b0,1'b0} :
+    // denormalized or zero
+    (s2t_f32_fract24_dn) ?                     // ine  ovf  inf 
+      {{s1o_sign,8'd0,s2t_f32_fract24[22:0]},s2t_lost,1'b0,1'b0,
+                                // unf        zer
+       (s2t_lost & s2t_f32_fract24_dn),~(|s2t_f32_fract24)} :
+    // normal result                                          ine  ovf  inf  unf  zer
+    {{s1o_sign,s2t_f32_exp10[7:0],s2t_f32_fract24[22:0]},s2t_lost,1'b0,1'b0,1'b0,1'b0};
+
+
+  // Output Register
+  always @(posedge clk `OR_ASYNC_RST) begin
+    if (rst) begin
+        // arithmetic results
+      fpu_result_o      <= 32'd0;
+      fpu_arith_valid_o <=  1'b0;
+        // comparison specials
+      fpu_cmp_flag_o  <= 1'b0;
+      fpu_cmp_valid_o <= 1'b0;
+        // exeptions
+      fpcsr_o         <= {`OR1K_FPCSR_WIDTH{1'b0}};
+    end
+    else if(flush_i) begin
+        // arithmetic results
+      fpu_result_o      <= 32'd0;
+      fpu_arith_valid_o <=  1'b0;
+        // comparison specials
+      fpu_cmp_flag_o  <= 1'b0;
+      fpu_cmp_valid_o <= 1'b0;
+        // exeptions
+      fpcsr_o         <= {`OR1K_FPCSR_WIDTH{1'b0}};
+    end
+    else if(adv_i) begin
+        // arithmetic results
+      fpu_result_o      <= s2t_opc;
+      fpu_arith_valid_o <= s1o_ready;
+        // comparison specials
+      fpu_cmp_flag_o  <= cmp_res_i;
+      fpu_cmp_valid_o <= cmp_rdy_i;
+        // exeptions
+      fpcsr_o[`OR1K_FPCSR_OVF] <= s2t_ovf;
+      fpcsr_o[`OR1K_FPCSR_UNF] <= s2t_unf;
+      fpcsr_o[`OR1K_FPCSR_SNF] <= s1o_inv | (s1o_snan_i & s1o_f2i);
+      fpcsr_o[`OR1K_FPCSR_QNF] <= s1o_qnan_i;
+      fpcsr_o[`OR1K_FPCSR_ZF]  <= s2t_zer;
+      fpcsr_o[`OR1K_FPCSR_IXF] <= s2t_ine;
+      fpcsr_o[`OR1K_FPCSR_IVF] <= (s1o_inv | (s2t_i32_inv & s1o_f2i) | s1o_snan_i) |
+                                  (cmp_inv_i & cmp_rdy_i);
+      fpcsr_o[`OR1K_FPCSR_INF] <= s2t_inf |
+                                  (cmp_inf_i & cmp_rdy_i);
+      fpcsr_o[`OR1K_FPCSR_DZF] <= s2t_dbz;
+    end
+  end // posedge clock
+
+endmodule // pfpu32_rnd

--- a/rtl/verilog/pfpu32/pfpu32_top.v
+++ b/rtl/verilog/pfpu32/pfpu32_top.v
@@ -1,0 +1,444 @@
+/////////////////////////////////////////////////////////////////////
+////                                                             ////
+////  pfpu32_top                                                 ////
+////  32-bit floating point top level                            ////
+////                                                             ////
+////  Author: Andrey Bacherov                                    ////
+////          avbacherov@opencores.org                           ////
+////                                                             ////
+/////////////////////////////////////////////////////////////////////
+////                                                             ////
+//// Copyright (C) 2014 Andrey Bacherov                          ////
+////                    avbacherov@opencores.org                 ////
+////                                                             ////
+//// This source file may be used and distributed without        ////
+//// restriction provided that this copyright statement is not   ////
+//// removed from the file and that any derivative work contains ////
+//// the original copyright notice and the associated disclaimer.////
+////                                                             ////
+////     THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY     ////
+//// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   ////
+//// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS   ////
+//// FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL THE AUTHOR      ////
+//// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,         ////
+//// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES    ////
+//// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE   ////
+//// GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR        ////
+//// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF  ////
+//// LIABILITY, WHETHER IN  CONTRACT, STRICT LIABILITY, OR TORT  ////
+//// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  ////
+//// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         ////
+//// POSSIBILITY OF SUCH DAMAGE.                                 ////
+////                                                             ////
+/////////////////////////////////////////////////////////////////////
+
+// fpu operations:
+// ==========================
+// 0000 = add,
+// 0001 = substract,
+// 0010 = multiply,
+// 0011 = divide,
+// 0100 = i2f
+// 0101 = f2i
+// 0110 = unused (rem)
+// 0111 = reserved
+// 1xxx = comparison
+
+`include "mor1kx-defines.v"
+
+module pfpu32_top
+#(
+  parameter OPTION_OPERAND_WIDTH = 32
+)
+(
+  input clk,
+  input rst,
+  input flush_i,
+  input padv_decode_i,
+  input padv_execute_i,
+  input [`OR1K_FPUOP_WIDTH-1:0]    op_fpu_i,
+  input [`OR1K_FPCSR_RM_SIZE-1:0]  round_mode_i,
+  input [OPTION_OPERAND_WIDTH-1:0] rfa_i,
+  input [OPTION_OPERAND_WIDTH-1:0] rfb_i,
+  output [OPTION_OPERAND_WIDTH-1:0] fpu_result_o,
+  output fpu_arith_valid_o,
+  output fpu_cmp_flag_o,
+  output fpu_cmp_valid_o,
+  output [`OR1K_FPCSR_WIDTH-1:0] fpcsr_o
+);
+
+// MSB (set by decode stage) indicates FPU instruction
+// Get rid of top bit - is FPU op valid bit
+wire   is_op_fpu = op_fpu_i[`OR1K_FPUOP_WIDTH-1];
+wire [`OR1K_FPUOP_WIDTH-1:0] op_fpu = {1'b0,op_fpu_i[`OR1K_FPUOP_WIDTH-2:0]};
+wire [2:0] op_arith_conv = op_fpu_i[2:0]; // alias
+wire a_cmp = op_fpu_i[3]; // alias for compare bit of fpu's opcode
+
+// advance FPU units
+wire padv_fpu_units = padv_execute_i |
+                      ((~fpu_arith_valid_o) & (~fpu_cmp_valid_o));
+
+// start logic
+reg new_data;
+always @(posedge clk `OR_ASYNC_RST) begin
+  if (rst)
+    new_data <= 1'b0;
+  else if(flush_i)
+    new_data <= 1'b0;
+  else if(padv_decode_i)
+    new_data <= 1'b1;
+  else if(padv_fpu_units)
+    new_data <= 1'b0;
+end // posedge clock
+
+wire new_fpu_data = new_data & is_op_fpu;
+
+
+// analysis of input values
+//   split input a
+wire        in_signa  = rfa_i[31];
+wire [7:0]  in_expa   = rfa_i[30:23];
+wire [22:0] in_fracta = rfa_i[22:0];
+//   detect infinity a
+wire in_expa_ff = &in_expa;
+wire in_infa    = in_expa_ff & (~(|in_fracta));
+//   signaling NaN: exponent is 8hff, [22] is zero,
+//                  rest of fract is non-zero
+//   quiet NaN: exponent is 8hff, [22] is 1
+wire in_snan_a = in_expa_ff & (~in_fracta[22]) & (|in_fracta[21:0]);
+wire in_qnan_a = in_expa_ff &   in_fracta[22];
+//   denormalized/zero of a
+wire in_opa_0  = ~(|rfa_i[30:0]);
+wire in_opa_dn = (~(|in_expa)) & (|in_fracta);
+
+//   split input b
+wire        in_signb  = rfb_i[31];
+wire [7:0]  in_expb   = rfb_i[30:23];
+wire [22:0] in_fractb = rfb_i[22:0];
+//   detect infinity b
+wire in_expb_ff = &in_expb;
+wire in_infb    = in_expb_ff & (~(|in_fractb));
+//   detect NaNs in b
+wire in_snan_b = in_expb_ff & (~in_fractb[22]) & (|in_fractb[21:0]);
+wire in_qnan_b = in_expb_ff &   in_fractb[22];
+//   denormalized/zero of a
+wire in_opb_0  = ~(|rfb_i[30:0]);
+wire in_opb_dn = (~(|in_expb)) & (|in_fractb);
+
+// detection of some exceptions
+//   a nan input -> qnan output
+wire in_snan = in_snan_a | in_snan_b;
+wire in_qnan = in_qnan_a | in_qnan_b;
+//   sign of output nan
+wire in_anan_sign = (in_snan_a | in_qnan_a) ? in_signa :
+                                              in_signb;
+
+// restored exponents
+wire [9:0] in_exp10a = {2'd0,in_expa[7:1],(in_expa[0] | in_opa_dn)};
+wire [9:0] in_exp10b = {2'd0,in_expb[7:1],(in_expb[0] | in_opb_dn)};
+// restored fractionals
+wire [23:0] in_fract24a = {((~in_opa_dn) & (~in_opa_0)),in_fracta};
+wire [23:0] in_fract24b = {((~in_opb_dn) & (~in_opb_0)),in_fractb};
+
+
+// comparator
+//   inputs & outputs
+wire op_cmp = a_cmp &
+              new_fpu_data;
+wire addsub_agtb_o, addsub_aeqb_o;
+wire cmp_result, cmp_ready,
+     cmp_inv, cmp_inf;
+//   module istance
+pfpu32_fcmp u_f32_cmp
+(
+  .fpu_op_is_comp_i(op_cmp),
+  .cmp_type_i(op_fpu),
+  // operand 'a' related inputs
+  .signa_i(in_signa),
+  .exp10a_i(in_exp10a),
+  .fract24a_i(in_fract24a),
+  .snana_i(in_snan_a),
+  .qnana_i(in_qnan_a),
+  .infa_i(in_infa),
+  .zeroa_i(in_opa_0),
+  // operand 'b' related inputs
+  .signb_i(in_signb),
+  .exp10b_i(in_exp10b),
+  .fract24b_i(in_fract24b),
+  .snanb_i(in_snan_b),
+  .qnanb_i(in_qnan_b),
+  .infb_i(in_infb),
+  .zerob_i(in_opb_0),
+  // support addsub
+  .addsub_agtb_o(addsub_agtb_o),
+  .addsub_aeqb_o(addsub_aeqb_o),
+  // outputs
+  .cmp_flag_o(cmp_result),
+  .inv_o(cmp_inv),
+  .inf_o(cmp_inf),
+  .ready_o(cmp_ready)
+);
+
+
+// addition / substraction
+//   inputs & outputs
+wire the_sub   = (op_arith_conv == 3'd1);
+wire op_add    = (~a_cmp) & ((op_arith_conv == 3'd0) | the_sub);
+wire add_start = op_add & 
+                 new_fpu_data;
+wire        add_rdy_o;       // add/sub is ready
+wire        add_sign_o;      // add/sub signum
+wire        add_sub_0_o;     // flag that actual substruction is performed and result is zero
+wire  [4:0] add_shl_o;       // do left shift in align stage
+wire  [9:0] add_exp10shl_o;  // exponent for left shift align
+wire  [9:0] add_exp10sh0_o;  // exponent for no shift in align
+wire [27:0] add_fract28_o;   // fractional with appended {r,s} bits
+wire        add_inv_o;       // add/sub invalid operation flag
+wire        add_inf_o;       // add/sub infinity output reg
+wire        add_snan_o;      // add/sub signaling NaN output reg
+wire        add_qnan_o;      // add/sub quiet NaN output reg
+wire        add_anan_sign_o; // add/sub signum for output nan
+//   module istance
+pfpu32_addsub u_f32_addsub
+(
+  .clk           (clk),
+  .rst           (rst),
+  .flush_i       (flush_i),        // flushe pipe
+  .adv_i         (padv_fpu_units), // advance pipe
+  .start_i       (add_start), 
+  .is_sub_i      (the_sub),        // 1: substruction, 0: addition
+  // input 'a' related values
+  .signa_i       (in_signa),
+  .exp10a_i      (in_exp10a),
+  .fract24a_i    (in_fract24a),
+  .infa_i        (in_infa),
+  // input 'b' related values
+  .signb_i       (in_signb),
+  .exp10b_i      (in_exp10b),
+  .fract24b_i    (in_fract24b),
+  .infb_i        (in_infb),
+  // 'a'/'b' related
+  .snan_i        (in_snan),
+  .qnan_i        (in_qnan),
+  .anan_sign_i   (in_anan_sign),
+  .addsub_agtb_i (addsub_agtb_o),
+  .addsub_aeqb_i (addsub_aeqb_o),
+  // outputs
+  .add_rdy_o       (add_rdy_o),       // add/sub is ready
+  .add_sign_o      (add_sign_o),      // add/sub signum
+  .add_sub_0_o     (add_sub_0_o),     // flag that actual substruction is performed and result is zero
+  .add_shl_o       (add_shl_o),       // do left shift in align stage
+  .add_exp10shl_o  (add_exp10shl_o),  // exponent for left shift align
+  .add_exp10sh0_o  (add_exp10sh0_o),  // exponent for no shift in align
+  .add_fract28_o   (add_fract28_o),   // fractional with appended {r,s} bits
+  .add_inv_o       (add_inv_o),       // add/sub invalid operation flag
+  .add_inf_o       (add_inf_o),       // add/sub infinity output reg
+  .add_snan_o      (add_snan_o),      // add/sub signaling NaN output reg
+  .add_qnan_o      (add_qnan_o),      // add/sub quiet NaN output reg
+  .add_anan_sign_o (add_anan_sign_o)  // add/sub signum for output nan
+);
+
+// MUL/DIV combined pipeline
+//   inputs & outputs
+wire op_mul    = (~a_cmp) & (op_arith_conv == 3'd2);
+wire op_div    = (~a_cmp) & (op_arith_conv == 3'd3);
+wire mul_start = (op_mul | op_div) & 
+                 new_fpu_data;
+// MUL/DIV common outputs
+wire        mul_rdy_o;       // mul is ready
+wire        mul_sign_o;      // mul signum
+wire  [4:0] mul_shr_o;       // do right shift in align stage
+wire  [9:0] mul_exp10shr_o;  // exponent for right shift align
+wire        mul_shl_o;       // do left shift in align stage
+wire  [9:0] mul_exp10shl_o;  // exponent for left shift align
+wire  [9:0] mul_exp10sh0_o;  // exponent for no shift in align
+wire [27:0] mul_fract28_o;   // fractional with appended {r,s} bits
+wire        mul_inv_o;       // mul invalid operation flag
+wire        mul_inf_o;       // mul infinity output reg
+wire        mul_snan_o;      // mul signaling NaN output reg
+wire        mul_qnan_o;      // mul quiet NaN output reg
+wire        mul_anan_sign_o; // mul signum for output nan
+// DIV additional outputs
+wire        div_op_o;        // operation is division
+wire        div_sign_rmnd_o; // signum or reminder for IEEE compliant rounding
+wire        div_dbz_o;       // division by zero flag
+//   module istance
+pfpu32_muldiv u_f32_muldiv
+(
+  .clk         (clk),
+  .rst         (rst),
+  .flush_i     (flush_i),        // flushe pipe
+  .adv_i       (padv_fpu_units), // advance pipe
+  .start_i     (mul_start),
+  .is_div_i    (op_div),
+  // input 'a' related values
+  .signa_i     (in_signa),
+  .exp10a_i    (in_exp10a),
+  .fract24a_i  (in_fract24a),
+  .infa_i      (in_infa),
+  .zeroa_i     (in_opa_0),
+  // input 'b' related values
+  .signb_i     (in_signb),
+  .exp10b_i    (in_exp10b),
+  .fract24b_i  (in_fract24b),
+  .infb_i      (in_infb),
+  .zerob_i     (in_opb_0),
+  // 'a'/'b' related
+  .snan_i      (in_snan),        
+  .qnan_i      (in_qnan),
+  .anan_sign_i (in_anan_sign),
+  // MUL/DIV common outputs
+  .muldiv_rdy_o       (mul_rdy_o),       // mul is ready
+  .muldiv_sign_o      (mul_sign_o),      // mul signum
+  .muldiv_shr_o       (mul_shr_o),       // do right shift in align stage
+  .muldiv_exp10shr_o  (mul_exp10shr_o),  // exponent for right shift align
+  .muldiv_shl_o       (mul_shl_o),       // do left shift in align stage
+  .muldiv_exp10shl_o  (mul_exp10shl_o),  // exponent for left shift align
+  .muldiv_exp10sh0_o  (mul_exp10sh0_o),  // exponent for no shift in align
+  .muldiv_fract28_o   (mul_fract28_o),   // fractional with appended {r,s} bits
+  .muldiv_inv_o       (mul_inv_o),       // mul invalid operation flag
+  .muldiv_inf_o       (mul_inf_o),       // mul infinity output reg
+  .muldiv_snan_o      (mul_snan_o),      // mul signaling NaN output reg
+  .muldiv_qnan_o      (mul_qnan_o),      // mul quiet NaN output reg
+  .muldiv_anan_sign_o (mul_anan_sign_o), // mul signum for output nan
+  // DIV additional outputs
+  .div_op_o(div_op_o),                  // operation is division
+  .div_sign_rmnd_o(div_sign_rmnd_o),    // signum of reminder for IEEE compliant rounding
+  .div_dbz_o(div_dbz_o)                 // division by zero flag
+);
+
+// convertor
+//   i2f signals
+wire op_i2f_cnv = (~a_cmp) & (op_arith_conv == 3'd4);
+wire i2f_start  = op_i2f_cnv & 
+                  new_fpu_data;
+wire        i2f_rdy_o;       // i2f is ready
+wire        i2f_sign_o;      // i2f signum
+wire  [3:0] i2f_shr_o;
+wire  [7:0] i2f_exp8shr_o;
+wire  [4:0] i2f_shl_o;
+wire  [7:0] i2f_exp8shl_o;
+wire  [7:0] i2f_exp8sh0_o;
+wire [31:0] i2f_fract32_o;
+//   i2f module instance
+pfpu32_i2f u_i2f_cnv
+(
+  .clk         (clk),
+  .rst         (rst),
+  .flush_i     (flush_i),        // flush pipe
+  .adv_i       (padv_fpu_units), // advance pipe
+  .start_i     (i2f_start),      // start conversion
+  .opa_i       (rfa_i),
+  .i2f_rdy_o     (i2f_rdy_o),     // i2f is ready
+  .i2f_sign_o    (i2f_sign_o),    // i2f signum
+  .i2f_shr_o     (i2f_shr_o),
+  .i2f_exp8shr_o (i2f_exp8shr_o),
+  .i2f_shl_o     (i2f_shl_o),
+  .i2f_exp8shl_o (i2f_exp8shl_o),
+  .i2f_exp8sh0_o (i2f_exp8sh0_o),
+  .i2f_fract32_o (i2f_fract32_o)
+);
+//   f2i signals
+wire op_f2i_cnv = (~a_cmp) & (op_arith_conv == 3'd5);
+wire f2i_start  = op_f2i_cnv & 
+                  new_fpu_data;
+wire        f2i_rdy_o;       // f2i is ready
+wire        f2i_sign_o;      // f2i signum
+wire [23:0] f2i_int24_o;     // f2i fractional
+wire  [4:0] f2i_shr_o;       // f2i required shift right value
+wire  [3:0] f2i_shl_o;       // f2i required shift left value   
+wire        f2i_ovf_o;       // f2i overflow flag
+wire        f2i_snan_o;      // f2i signaling NaN output reg
+//    f2i module instance
+pfpu32_f2i u_f2i_cnv
+(
+  .clk         (clk),
+  .rst         (rst),
+  .flush_i     (flush_i),        // flush pipe
+  .adv_i       (padv_fpu_units), // advance pipe
+  .start_i     (f2i_start),      // start conversion
+  .signa_i     (in_signa),       // input 'a' related values
+  .exp10a_i    (in_exp10a),
+  .fract24a_i  (in_fract24a),
+  .snan_i      (in_snan),        // 'a'/'b' related
+  .qnan_i      (in_qnan),
+  .f2i_rdy_o   (f2i_rdy_o),       // f2i is ready
+  .f2i_sign_o  (f2i_sign_o),      // f2i signum
+  .f2i_int24_o (f2i_int24_o),     // f2i fractional
+  .f2i_shr_o   (f2i_shr_o),       // f2i required shift right value
+  .f2i_shl_o   (f2i_shl_o),       // f2i required shift left value   
+  .f2i_ovf_o   (f2i_ovf_o),       // f2i overflow flag
+  .f2i_snan_o  (f2i_snan_o)       // f2i signaling NaN output reg
+);
+
+
+// multiplexing and rounding
+pfpu32_rnd u_f32_rnd
+(
+  // clocks, resets and other controls
+  .clk             (clk),
+  .rst             (rst),
+  .flush_i         (flush_i),         // flush pipe
+  .adv_i           (padv_fpu_units),  // advance pipe
+  .rmode_i         (round_mode_i),    // rounding mode
+  // from add/sub
+  .add_rdy_i       (add_rdy_o),       // add/sub is ready
+  .add_sign_i      (add_sign_o),      // add/sub signum
+  .add_sub_0_i     (add_sub_0_o),     // flag that actual substruction is performed and result is zero
+  .add_shl_i       (add_shl_o),       // do left shift in align stage
+  .add_exp10shl_i  (add_exp10shl_o),  // exponent for left shift align
+  .add_exp10sh0_i  (add_exp10sh0_o),  // exponent for no shift in align
+  .add_fract28_i   (add_fract28_o),   // fractional with appended {r,s} bits
+  .add_inv_i       (add_inv_o),       // add/sub invalid operation flag
+  .add_inf_i       (add_inf_o),       // add/sub infinity
+  .add_snan_i      (add_snan_o),      // add/sub signaling NaN
+  .add_qnan_i      (add_qnan_o),      // add/sub quiet NaN
+  .add_anan_sign_i (add_anan_sign_o), // add/sub signum for output nan
+  // from mul
+  .mul_rdy_i       (mul_rdy_o),       // mul is ready
+  .mul_sign_i      (mul_sign_o),      // mul signum
+  .mul_shr_i       (mul_shr_o),       // do right shift in align stage
+  .mul_exp10shr_i  (mul_exp10shr_o),  // exponent for right shift align
+  .mul_shl_i       (mul_shl_o),       // do left shift in align stage
+  .mul_exp10shl_i  (mul_exp10shl_o),  // exponent for left shift align
+  .mul_exp10sh0_i  (mul_exp10sh0_o),  // exponent for no shift in align
+  .mul_fract28_i   (mul_fract28_o),   // fractional with appended {r,s} bits
+  .mul_inv_i       (mul_inv_o),       // mul invalid operation flag
+  .mul_inf_i       (mul_inf_o),       // mul infinity 
+  .mul_snan_i      (mul_snan_o),      // mul signaling NaN
+  .mul_qnan_i      (mul_qnan_o),      // mul quiet NaN
+  .mul_anan_sign_i (mul_anan_sign_o), // mul signum for output nan
+  .div_op_i        (div_op_o),         // MUL/DIV output is division
+  .div_sign_rmnd_i (div_sign_rmnd_o),  // signum or reminder for IEEE compliant rounding
+  .div_dbz_i       (div_dbz_o),        // division by zero flag
+  // from i2f
+  .i2f_rdy_i       (i2f_rdy_o),       // i2f is ready
+  .i2f_sign_i      (i2f_sign_o),      // i2f signum
+  .i2f_shr_i       (i2f_shr_o),
+  .i2f_exp8shr_i   (i2f_exp8shr_o),
+  .i2f_shl_i       (i2f_shl_o),
+  .i2f_exp8shl_i   (i2f_exp8shl_o),
+  .i2f_exp8sh0_i   (i2f_exp8sh0_o),
+  .i2f_fract32_i   (i2f_fract32_o),
+  // from f2i
+  .f2i_rdy_i       (f2i_rdy_o),       // f2i is ready
+  .f2i_sign_i      (f2i_sign_o),      // f2i signum
+  .f2i_int24_i     (f2i_int24_o),     // f2i fractional
+  .f2i_shr_i       (f2i_shr_o),       // f2i required shift right value
+  .f2i_shl_i       (f2i_shl_o),       // f2i required shift left value   
+  .f2i_ovf_i       (f2i_ovf_o),       // f2i overflow flag
+  .f2i_snan_i      (f2i_snan_o),      // f2i signaling NaN
+   // from cmp
+  .cmp_rdy_i       (cmp_ready),       // cmp is ready
+  .cmp_res_i       (cmp_result),      // cmp result
+  .cmp_inv_i       (cmp_inv),         // cmp invalid flag
+  .cmp_inf_i       (cmp_inf),         // cmp infinity flag
+  // outputs
+  .fpu_result_o      (fpu_result_o),
+  .fpu_arith_valid_o (fpu_arith_valid_o),
+  .fpu_cmp_flag_o    (fpu_cmp_flag_o),
+  .fpu_cmp_valid_o   (fpu_cmp_valid_o),
+  .fpcsr_o           (fpcsr_o)
+);
+
+endmodule // pfpu32_top


### PR DESCRIPTION
The new pull request for merging fpu32 into master.
To use FPU:
(1) add all files from verilog/pfpu32 folder into your project
(2) add .FEATURE_FPU("ENABLED") in parameter list of mor1kx instance
Comparison with OR1200's FPU.
Operation clock cost for: ADD/SUB - MUL - DIV - I2F/F2I
Port of OR1200 FPU 8 - 36 - 35 - 6
Pipelined FPU 5 - 6 - 18 - 3
Size of standalone FPU (LUTs as logic, Spartan6, ISE14.6):
Port of OR1200 FPU : 2966 / 96 MHz
Pipelined FPU
DSP blocks arn't used : 2822 / 112 MHz
DSP blocks are used : 1554 / 76 MHz (+5 DSP modules)
Performance gain by Whetstone benchmark is up to 2 ... 3.5 times against OR1200's FPU and up to 20 times against soft-float depending on test. Detailed comparison will be published in mailing list after OpenRISC.NET operation restoring.
Additionally there is an extension to FPCSR. Thanks to the extension the each of FPU's exceptions could be masked separately. The extension is blocked by default till approve from community. To activate the extension, uncomment the OR1K_FPCSR_MASK_FLAGS macro in mor1kx-sprs.v
