### PR TITLE
Use variables after they have been defined

### DIFF
--- a/rtl/verilog/mor1kx_lsu_cappuccino.v
+++ b/rtl/verilog/mor1kx_lsu_cappuccino.v
@@ -245,9 +245,6 @@ module mor1kx_lsu_cappuccino
 
    assign lsu_except_dpagefault_o = except_dpagefault & !pipeline_flush_i;
 
-   // Stall until the store buffer is empty
-   assign msync_stall_o = ctrl_op_msync_i & (state == WRITE);
-
    always @(posedge clk `OR_ASYNC_RST)
      if (rst)
        access_done <= 0;
@@ -520,6 +517,9 @@ module mor1kx_lsu_cappuccino
    assign dbus_stall = tlb_reload_busy | except_align | except_dbus |
 		       except_dtlb_miss | except_dpagefault |
 		       pipeline_flush_i;
+
+   // Stall until the store buffer is empty
+   assign msync_stall_o = ctrl_op_msync_i & (state == WRITE);
 
 generate
 if (FEATURE_ATOMIC!="NONE") begin : atomic_gen


### PR DESCRIPTION
This bug was found by ModelSim:

** Error:
mor1kx_lsu_cappuccino.v(249):
(vlog-2730) Undefined variable: 'state'.
** Error:
mor1kx_lsu_cappuccino.v(249):
(vlog-2730) Undefined variable: 'WRITE'.
** Error:
mor1kx_lsu_cappuccino.v(353):
'WRITE' already declared in this scope.
** Error:
mor1kx_lsu_cappuccino.v(357):
'state' already declared in this scope (mor1kx_lsu_cappuccino).