### PR TITLE
Remove empty parameter lists

### DIFF
--- a/rtl/verilog/mor1kx_branch_predictor_saturation_counter.v
+++ b/rtl/verilog/mor1kx_branch_predictor_saturation_counter.v
@@ -23,8 +23,6 @@
 `include "mor1kx-defines.v"
 
 module mor1kx_branch_predictor_saturation_counter
-  #(
-    )
    (
     input clk,
     input rst,

--- a/rtl/verilog/mor1kx_branch_predictor_simple.v
+++ b/rtl/verilog/mor1kx_branch_predictor_simple.v
@@ -15,8 +15,6 @@
 `include "mor1kx-defines.v"
 
 module mor1kx_branch_predictor_simple
-  #(
-    )
    (
     // Signals belonging to the stage where the branch is predicted.
     input op_bf_i,               // branch if flag


### PR DESCRIPTION
Icarus doesn't handle empty parameter lists