### PR TITLE
Linter fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: true
+dist: trusty
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - autoconf
+
+before_install:
+  - cd /tmp
+  - git clone http://git.veripool.org/git/verilator
+  - cd verilator
+  - git checkout verilator_3_902
+  - autoconf
+  - ./configure
+  - make
+  - sudo make install
+  - cd $TRAVIS_BUILD_DIR
+
+script:
+  - verilator --lint-only rtl/verilog/*.v +incdir+rtl/verilog

--- a/rtl/verilog/mor1kx-sprs.v
+++ b/rtl/verilog/mor1kx-sprs.v
@@ -17,7 +17,7 @@
 //
 // Addresses
 //
-`define OR1K_SPR_SYS_BASE       {5'd0}
+`define OR1K_SPR_SYS_BASE       {4'd0}
 `define OR1K_SPR_VR_ADDR        {5'd0,11'd0}
 `define OR1K_SPR_UPR_ADDR       {5'd0,11'd1}
 `define OR1K_SPR_CPUCFGR_ADDR   {5'd0,11'd2}
@@ -44,7 +44,7 @@
 `define OR1K_SPR_NUMCORES_ADDR  {5'd0,11'd129}
 `define OR1K_SPR_GPR0_ADDR      {5'd0,11'd1024}
 
-`define OR1K_SPR_DMMU_BASE      {5'd1}
+`define OR1K_SPR_DMMU_BASE      {4'd1}
 `define OR1K_SPR_DMMUCR_ADDR    {5'd1,11'd0}
 `define OR1K_SPR_DMMUPR_ADDR    {5'd1,11'd1}
 `define OR1K_SPR_DTLBEIR_ADDR   {5'd1,11'd2}
@@ -59,7 +59,7 @@
 `define OR1K_SPR_DTLBW3MR0_ADDR {5'd1,11'd1280}
 `define OR1K_SPR_DTLBW3TR0_ADDR {5'd1,11'd1408}
 
-`define OR1K_SPR_IMMU_BASE      {5'd2}
+`define OR1K_SPR_IMMU_BASE      {4'd2}
 `define OR1K_SPR_IMMUCR_ADDR    {5'd2,11'd0}
 `define OR1K_SPR_IMMUPR_ADDR    {5'd2,11'd1}
 `define OR1K_SPR_ITLBEIR_ADDR   {5'd2,11'd2}
@@ -74,7 +74,7 @@
 `define OR1K_SPR_ITLBW3MR0_ADDR {5'd2,11'd1280}
 `define OR1K_SPR_ITLBW3TR0_ADDR {5'd2,11'd1408}
 
-`define OR1K_SPR_DC_BASE        {5'd3}
+`define OR1K_SPR_DC_BASE        {4'd3}
 `define OR1K_SPR_DCCR_ADDR      {5'd3,11'd0}
 `define OR1K_SPR_DCBPR_ADDR     {5'd3,11'd1}
 `define OR1K_SPR_DCBFR_ADDR     {5'd3,11'd2}
@@ -82,17 +82,17 @@
 `define OR1K_SPR_DCBWR_ADDR     {5'd3,11'd4}
 `define OR1K_SPR_DCBLR_ADDR     {5'd3,11'd5}
 
-`define OR1K_SPR_IC_BASE        {5'd4}
+`define OR1K_SPR_IC_BASE        {4'd4}
 `define OR1K_SPR_ICCR_ADDR      {5'd4,11'd0}
 `define OR1K_SPR_ICBPR_ADDR     {5'd4,11'd1}
 `define OR1K_SPR_ICBIR_ADDR     {5'd4,11'd2}
 `define OR1K_SPR_ICBLR_ADDR     {5'd4,11'd3}
 
-`define OR1K_SPR_MAC_BASE       {5'd5}
+`define OR1K_SPR_MAC_BASE       {4'd5}
 `define OR1K_SPR_MACLO_ADDR     {5'd5,11'd1}
 `define OR1K_SPR_MACHI_ADDR     {5'd5,11'd2}
 
-`define OR1K_SPR_DU_BASE        {5'd6}
+`define OR1K_SPR_DU_BASE        {4'd6}
 `define OR1K_SPR_DVR0_ADDR      {5'd6,11'd0}
 `define OR1K_SPR_DCR0_ADDR      {5'd6,11'd8}
 `define OR1K_SPR_DMR1_ADDR      {5'd6,11'd16}
@@ -101,7 +101,7 @@
 `define OR1K_SPR_DSR_ADDR       {5'd6,11'd20}
 `define OR1K_SPR_DRR_ADDR       {5'd6,11'd21}
 
-`define OR1K_SPR_PC_BASE        {5'd7}
+`define OR1K_SPR_PC_BASE        {4'd7}
 `define OR1K_SPR_PCCR0_ADDR     {5'd7,11'd0}
 `define OR1K_SPR_PCCR1_ADDR     {5'd7,11'd1}
 `define OR1K_SPR_PCCR2_ADDR     {5'd7,11'd2}
@@ -119,18 +119,18 @@
 `define OR1K_SPR_PCMR6_ADDR     {5'd7,11'd14}
 `define OR1K_SPR_PCMR7_ADDR     {5'd7,11'd15}
 
-`define OR1K_SPR_PM_BASE        {5'd8}
+`define OR1K_SPR_PM_BASE        {4'd8}
 `define OR1K_SPR_PMR_ADDR       {5'd8,11'd0}
 
-`define OR1K_SPR_PIC_BASE       {5'd9}
+`define OR1K_SPR_PIC_BASE       {4'd9}
 `define OR1K_SPR_PICMR_ADDR     {5'd9,11'd0}
 `define OR1K_SPR_PICSR_ADDR     {5'd9,11'd2}
 
-`define OR1K_SPR_TT_BASE        {5'd10}
+`define OR1K_SPR_TT_BASE        {4'd10}
 `define OR1K_SPR_TTMR_ADDR      {5'd10,11'd0}
 `define OR1K_SPR_TTCR_ADDR      {5'd10,11'd1}
 
-`define OR1K_SPR_FPU_BASE       {5'd11}
+`define OR1K_SPR_FPU_BASE       {4'd11}
 
 //
 // Register bit defines

--- a/rtl/verilog/mor1kx_branch_prediction.v
+++ b/rtl/verilog/mor1kx_branch_prediction.v
@@ -19,7 +19,7 @@
 
 module mor1kx_branch_prediction
   #(
-    parameter FEATURE_BRANCH_PREDICTOR = "NONE",
+    parameter [95:0] FEATURE_BRANCH_PREDICTOR = "NONE",
     parameter OPTION_OPERAND_WIDTH = 32
     )
    (

--- a/rtl/verilog/mor1kx_cfgrs.v
+++ b/rtl/verilog/mor1kx_cfgrs.v
@@ -32,7 +32,7 @@ module mor1kx_cfgrs
     parameter OPTION_DCACHE_SET_WIDTH    = 9,
     parameter OPTION_DCACHE_WAYS         = 2,
     parameter FEATURE_DMMU               = "NONE",
-    parameter OPTION_DMMU_SET_WIDTH      = 6,
+    parameter [2:0] OPTION_DMMU_SET_WIDTH      = 6,
     parameter OPTION_DMMU_WAYS           = 1,
     parameter FEATURE_INSTRUCTIONCACHE   = "NONE",
     parameter OPTION_ICACHE_BLOCK_WIDTH  = 5,

--- a/rtl/verilog/mor1kx_cpu_cappuccino.v
+++ b/rtl/verilog/mor1kx_cpu_cappuccino.v
@@ -1130,16 +1130,16 @@ module mor1kx_cpu_cappuccino
    /* Debug signals required for the debug monitor */
    function [OPTION_OPERAND_WIDTH-1:0] get_gpr;
       // verilator public
-      input [4:0] 		   gpr_num;
+      input [mor1kx_rf_cappuccino.RF_ADDR_WIDTH-1:0] gpr_num;
       begin
 	 // TODO: handle load ops
-	 if ((mor1kx_rf_cappuccino.execute_rfd_adr_i == gpr_num) &
+	 if ((mor1kx_rf_cappuccino.execute_rfd_adr_i == gpr_num[4:0]) &
 	     mor1kx_rf_cappuccino.execute_rf_wb_i)
 	   get_gpr = alu_result_o;
-	 else if ((mor1kx_rf_cappuccino.ctrl_rfd_adr_i == gpr_num) &
+	 else if ((mor1kx_rf_cappuccino.ctrl_rfd_adr_i == gpr_num[4:0]) &
 		  mor1kx_rf_cappuccino.ctrl_rf_wb_i)
 	   get_gpr = ctrl_alu_result_o;
-	 else if ((mor1kx_rf_cappuccino.wb_rfd_adr_i == gpr_num) &
+	 else if ((mor1kx_rf_cappuccino.wb_rfd_adr_i == gpr_num[4:0]) &
 		  mor1kx_rf_cappuccino.wb_rf_wb_i)
 	   get_gpr = mor1kx_rf_cappuccino.result_i;
 	 else
@@ -1150,7 +1150,7 @@ module mor1kx_cpu_cappuccino
 
    task set_gpr;
       // verilator public
-      input [4:0] gpr_num;
+      input [mor1kx_rf_cappuccino.RF_ADDR_WIDTH-1:0] gpr_num;
       input [OPTION_OPERAND_WIDTH-1:0] gpr_value;
       begin
 	 mor1kx_rf_cappuccino.rfa.mem[gpr_num] = gpr_value;

--- a/rtl/verilog/mor1kx_cpu_prontoespresso.v
+++ b/rtl/verilog/mor1kx_cpu_prontoespresso.v
@@ -183,14 +183,15 @@ module mor1kx_cpu_prontoespresso
    wire			decode_op_div_signed_o;	// From mor1kx_decode of mor1kx_decode.v
    wire			decode_op_div_unsigned_o;// From mor1kx_decode of mor1kx_decode.v
    wire			decode_op_ffl1_o;	// From mor1kx_decode of mor1kx_decode.v
+   wire [`OR1K_FPUOP_WIDTH-1:0] decode_op_fpu_o;// From mor1kx_decode of mor1kx_decode.v
    wire			decode_op_jal_o;	// From mor1kx_decode of mor1kx_decode.v
    wire			decode_op_jbr_o;	// From mor1kx_decode of mor1kx_decode.v
    wire			decode_op_jr_o;		// From mor1kx_decode of mor1kx_decode.v
-   wire			decode_op_lsu_atomic_o;	// From mor1kx_decode of mor1kx_decode.v
    wire			decode_op_lsu_load_o;	// From mor1kx_decode of mor1kx_decode.v
    wire			decode_op_lsu_store_o;	// From mor1kx_decode of mor1kx_decode.v
    wire			decode_op_mfspr_o;	// From mor1kx_decode of mor1kx_decode.v
    wire			decode_op_movhi_o;	// From mor1kx_decode of mor1kx_decode.v
+   wire			decode_op_msync_o;	// From mor1kx_decode of mor1kx_decode.v
    wire			decode_op_mtspr_o;	// From mor1kx_decode of mor1kx_decode.v
    wire			decode_op_mul_o;	// From mor1kx_decode of mor1kx_decode.v
    wire			decode_op_mul_signed_o;	// From mor1kx_decode of mor1kx_decode.v
@@ -220,6 +221,8 @@ module mor1kx_cpu_prontoespresso
    wire			flag_clear_o;		// From mor1kx_execute_alu of mor1kx_execute_alu.v
    wire			flag_o;			// From mor1kx_ctrl_prontoespresso of mor1kx_ctrl_prontoespresso.v
    wire			flag_set_o;		// From mor1kx_execute_alu of mor1kx_execute_alu.v
+   wire [`OR1K_FPCSR_WIDTH-1:0] fpcsr_o;	// From mor1kx_execute_alu of mor1kx_execute_alu.v
+   wire			fpcsr_set_o;		// From mor1kx_execute_alu of mor1kx_execute_alu.v
    wire [OPTION_OPERAND_WIDTH-1:0] link_addr_o;	// From mor1kx_ctrl_prontoespresso of mor1kx_ctrl_prontoespresso.v
    wire			lsu_except_align_o;	// From mor1kx_lsu_espresso of mor1kx_lsu_espresso.v
    wire			lsu_except_dbus_o;	// From mor1kx_lsu_espresso of mor1kx_lsu_espresso.v
@@ -441,7 +444,7 @@ module mor1kx_cpu_prontoespresso
       .decode_op_alu_o			(decode_op_alu_o),
       .decode_op_lsu_load_o		(decode_op_lsu_load_o),
       .decode_op_lsu_store_o		(decode_op_lsu_store_o),
-      .decode_op_lsu_atomic_o		(decode_op_lsu_atomic_o),
+      .decode_op_lsu_atomic_o		(),			 // Templated
       .decode_lsu_length_o		(decode_lsu_length_o[1:0]),
       .decode_lsu_zext_o		(decode_lsu_zext_o),
       .decode_op_mfspr_o		(decode_op_mfspr_o),
@@ -458,6 +461,8 @@ module mor1kx_cpu_prontoespresso
       .decode_op_shift_o		(decode_op_shift_o),
       .decode_op_ffl1_o			(decode_op_ffl1_o),
       .decode_op_movhi_o		(decode_op_movhi_o),
+      .decode_op_msync_o		(decode_op_msync_o),
+      .decode_op_fpu_o			(decode_op_fpu_o[`OR1K_FPUOP_WIDTH-1:0]),
       .decode_adder_do_sub_o		(decode_adder_do_sub_o),
       .decode_adder_do_carry_o		(decode_adder_do_carry_o),
       .decode_except_illegal_o		(decode_except_illegal_o),
@@ -470,14 +475,19 @@ module mor1kx_cpu_prontoespresso
       .decode_insn_i			(insn_fetch_to_decode));	 // Templated
 
    /* mor1kx_execute_alu AUTO_TEMPLATE (
+    .padv_decode_i			(padv_decode_o),
     .padv_execute_i			(padv_execute_o),
     .padv_ctrl_i			(1'b1),
+    .pipeline_flush_i			(pipeline_flush_o),
     .opc_alu_i			        (decode_opc_alu_o),
     .opc_alu_secondary_i		(decode_opc_alu_secondary_o),
     .imm16_i				(decode_imm16_o),
     .immediate_i			(decode_immediate_o),
     .immediate_sel_i			(decode_immediate_sel_o),
     .decode_valid_i			(padv_decode_o),
+    .decode_immediate_i		        (decode_immediate_o),
+    .decode_immediate_sel_i		(decode_immediate_sel_o),
+    .decode_op_mul_i			(decode_op_mul_o),
     .op_alu_i				(decode_op_alu_o),
     .op_add_i				(decode_op_add_o),
     .op_mul_i				(decode_op_mul_o),
@@ -494,10 +504,14 @@ module mor1kx_cpu_prontoespresso
     .op_movhi_i				(decode_op_movhi_o),
     .op_jbr_i				(decode_op_jbr_o),
     .op_jr_i				(decode_op_jr_o),
+    .op_fpu_i				(decode_op_fpu_o),
+    .fpu_round_mode_i                   (2'b00),
     .immjbr_upper_i			(decode_immjbr_upper_o),
     .pc_execute_i			(spr_ppc_o),
     .adder_do_sub_i			(decode_adder_do_sub_o),
     .adder_do_carry_i			(decode_adder_do_carry_o),
+    .decode_rfa_i			(rfa_o),
+    .decode_rfb_i			(rfb_o),
     .rfa_i				(rfa_o),
     .rfb_i				(rfb_o),
     .flag_i                             (flag_o),
@@ -533,6 +547,8 @@ module mor1kx_cpu_prontoespresso
       .carry_clear_o			(carry_clear_o),
       .overflow_set_o			(overflow_set_o),
       .overflow_clear_o			(overflow_clear_o),
+      .fpcsr_o				(fpcsr_o[`OR1K_FPCSR_WIDTH-1:0]),
+      .fpcsr_set_o			(fpcsr_set_o),
       .alu_result_o			(alu_result_o[OPTION_OPERAND_WIDTH-1:0]),
       .alu_valid_o			(alu_valid_o),
       .mul_result_o			(mul_result_o[OPTION_OPERAND_WIDTH-1:0]),
@@ -540,14 +556,19 @@ module mor1kx_cpu_prontoespresso
       // Inputs
       .clk				(clk),
       .rst				(rst),
+      .padv_decode_i			(padv_decode_o),	 // Templated
       .padv_execute_i			(padv_execute_o),	 // Templated
       .padv_ctrl_i			(1'b1),			 // Templated
+      .pipeline_flush_i			(pipeline_flush_o),	 // Templated
       .opc_alu_i			(decode_opc_alu_o),	 // Templated
       .opc_alu_secondary_i		(decode_opc_alu_secondary_o), // Templated
       .imm16_i				(decode_imm16_o),	 // Templated
       .immediate_i			(decode_immediate_o),	 // Templated
       .immediate_sel_i			(decode_immediate_sel_o), // Templated
+      .decode_immediate_i		(decode_immediate_o),	 // Templated
+      .decode_immediate_sel_i		(decode_immediate_sel_o), // Templated
       .decode_valid_i			(padv_decode_o),	 // Templated
+      .decode_op_mul_i			(decode_op_mul_o),	 // Templated
       .op_alu_i				(decode_op_alu_o),	 // Templated
       .op_add_i				(decode_op_add_o),	 // Templated
       .op_mul_i				(decode_op_mul_o),	 // Templated
@@ -562,12 +583,16 @@ module mor1kx_cpu_prontoespresso
       .op_mtspr_i			(decode_op_mtspr_o),	 // Templated
       .op_mfspr_i			(decode_op_mfspr_o),	 // Templated
       .op_movhi_i			(decode_op_movhi_o),	 // Templated
+      .op_fpu_i				(decode_op_fpu_o),	 // Templated
+      .fpu_round_mode_i			(2'b00),		 // Templated
       .op_jbr_i				(decode_op_jbr_o),	 // Templated
       .op_jr_i				(decode_op_jr_o),	 // Templated
       .immjbr_upper_i			(decode_immjbr_upper_o), // Templated
       .pc_execute_i			(spr_ppc_o),		 // Templated
       .adder_do_sub_i			(decode_adder_do_sub_o), // Templated
       .adder_do_carry_i			(decode_adder_do_carry_o), // Templated
+      .decode_rfa_i			(rfa_o),		 // Templated
+      .decode_rfb_i			(rfb_o),		 // Templated
       .rfa_i				(rfa_o),		 // Templated
       .rfb_i				(rfb_o),		 // Templated
       .flag_i				(flag_o),		 // Templated

--- a/rtl/verilog/mor1kx_ctrl_cappuccino.v
+++ b/rtl/verilog/mor1kx_ctrl_cappuccino.v
@@ -329,6 +329,7 @@ module mor1kx_ctrl_cappuccino
    wire 			     spr_write_access;
    wire 			     spr_bus_access;
    reg [OPTION_OPERAND_WIDTH-1:0]    spr_sys_group_read;
+   wire [3:0] 			     spr_group;
 
    /* Wires from mor1kx_cfgrs module */
    wire [31:0] 			     spr_vr;
@@ -1184,10 +1185,12 @@ module mor1kx_ctrl_cappuccino
                           spr_access_valid & spr_bus_access;
    assign spr_bus_dat_o = spr_write_dat;
 
+   assign spr_group = spr_addr[14:11];
+
    /* Select spr */
    always @(*) begin
      spr_access = 0;
-      case(`SPR_BASE(spr_addr))
+      case(spr_group)
          // System group
          `OR1K_SPR_SYS_BASE:
            spr_access[`OR1K_SPR_SYS_BASE] = 1'b1;

--- a/rtl/verilog/mor1kx_ctrl_cappuccino.v
+++ b/rtl/verilog/mor1kx_ctrl_cappuccino.v
@@ -1186,47 +1186,47 @@ module mor1kx_ctrl_cappuccino
 
    /* Select spr */
    always @(*) begin
-     spr_access <= 0;
+     spr_access = 0;
       case(`SPR_BASE(spr_addr))
          // System group
          `OR1K_SPR_SYS_BASE:
-           spr_access[`OR1K_SPR_SYS_BASE] <= 1'b1;
+           spr_access[`OR1K_SPR_SYS_BASE] = 1'b1;
          // DMMU
          `OR1K_SPR_DMMU_BASE:
-           spr_access[`OR1K_SPR_DMMU_BASE] <= (FEATURE_DMMU!="NONE");
+           spr_access[`OR1K_SPR_DMMU_BASE] = (FEATURE_DMMU!="NONE");
          // IMMU
          `OR1K_SPR_IMMU_BASE:
-           spr_access[`OR1K_SPR_IMMU_BASE] <= (FEATURE_IMMU!="NONE");
+           spr_access[`OR1K_SPR_IMMU_BASE] = (FEATURE_IMMU!="NONE");
          // Data cache
          `OR1K_SPR_DC_BASE:
-           spr_access[`OR1K_SPR_DC_BASE] <= (FEATURE_DATACACHE!="NONE");
+           spr_access[`OR1K_SPR_DC_BASE] = (FEATURE_DATACACHE!="NONE");
          // Instruction cache
          `OR1K_SPR_IC_BASE:
-           spr_access[`OR1K_SPR_IC_BASE] <= (FEATURE_INSTRUCTIONCACHE!= "NONE");
+           spr_access[`OR1K_SPR_IC_BASE] = (FEATURE_INSTRUCTIONCACHE!= "NONE");
          // MAC unit
          `OR1K_SPR_MAC_BASE:
-           spr_access[`OR1K_SPR_MAC_BASE] <= (FEATURE_MAC!="NONE");
+           spr_access[`OR1K_SPR_MAC_BASE] = (FEATURE_MAC!="NONE");
          // Debug unit
          `OR1K_SPR_DU_BASE:
-           spr_access[`OR1K_SPR_DU_BASE] <= (FEATURE_DEBUGUNIT!="NONE");
+           spr_access[`OR1K_SPR_DU_BASE] = (FEATURE_DEBUGUNIT!="NONE");
          // Performance counters
          `OR1K_SPR_PC_BASE:
-           spr_access[`OR1K_SPR_PC_BASE] <= (FEATURE_PERFCOUNTERS!="NONE");
+           spr_access[`OR1K_SPR_PC_BASE] = (FEATURE_PERFCOUNTERS!="NONE");
          // Power Management
          `OR1K_SPR_PM_BASE:
-           spr_access[`OR1K_SPR_PM_BASE] <= (FEATURE_PMU!="NONE");
+           spr_access[`OR1K_SPR_PM_BASE] = (FEATURE_PMU!="NONE");
          // PIC
          `OR1K_SPR_PIC_BASE:
-           spr_access[`OR1K_SPR_PIC_BASE] <= (FEATURE_PIC!="NONE");
+           spr_access[`OR1K_SPR_PIC_BASE] = (FEATURE_PIC!="NONE");
          // Tick timer
          `OR1K_SPR_TT_BASE:
-           spr_access[`OR1K_SPR_TT_BASE] <= (FEATURE_TIMER!="NONE");
+           spr_access[`OR1K_SPR_TT_BASE] = (FEATURE_TIMER!="NONE");
          // FPU
          `OR1K_SPR_FPU_BASE:
-           spr_access[`OR1K_SPR_FPU_BASE] <= (FEATURE_FPU!="NONE");
+           spr_access[`OR1K_SPR_FPU_BASE] = (FEATURE_FPU!="NONE");
          /* generate invalid if the group is not present in the design  */
          default:
-           spr_access <= 0;
+           spr_access = 0;
        endcase
     end
 

--- a/rtl/verilog/mor1kx_ctrl_espresso.v
+++ b/rtl/verilog/mor1kx_ctrl_espresso.v
@@ -968,6 +968,7 @@ module mor1kx_ctrl_espresso
 	  .spr_dat_o		(spr_internal_read_dat[9]),
 	  // Inputs
 	  .spr_we_i		(spr_we),
+          .spr_access_i         (1'b1),
 	  .spr_addr_i		(spr_addr),
 	  .spr_dat_i		(spr_write_dat),
 	  );*/
@@ -987,6 +988,7 @@ module mor1kx_ctrl_espresso
 	    .clk			(clk),
 	    .rst			(rst),
 	    .irq_i			(irq_i[31:0]),
+	    .spr_access_i		(1'b1),			 // Templated
 	    .spr_we_i			(spr_we),		 // Templated
 	    .spr_addr_i			(spr_addr),		 // Templated
 	    .spr_dat_i			(spr_write_dat));	 // Templated
@@ -1023,6 +1025,7 @@ module mor1kx_ctrl_espresso
 	  .spr_dat_o		(spr_internal_read_dat[10]),
 	  // Inputs
 	  .spr_we_i		(spr_we),
+          .spr_access_i         (1'b1),
 	  .spr_addr_i		(spr_addr),
 	  .spr_dat_i		(spr_write_dat),
 	  );*/
@@ -1036,6 +1039,7 @@ module mor1kx_ctrl_espresso
 			  // Inputs
 			  .clk			(clk),
 			  .rst			(rst),
+			  .spr_access_i		(1'b1),		 // Templated
 			  .spr_we_i		(spr_we),	 // Templated
 			  .spr_addr_i		(spr_addr),	 // Templated
 			  .spr_dat_i		(spr_write_dat)); // Templated

--- a/rtl/verilog/mor1kx_ctrl_prontoespresso.v
+++ b/rtl/verilog/mor1kx_ctrl_prontoespresso.v
@@ -960,6 +960,7 @@ module mor1kx_ctrl_prontoespresso
 	  .spr_dat_o		(spr_internal_read_dat[9]),
 	  // Inputs
 	  .spr_we_i		(spr_we),
+          .spr_access_i         (1'b1),
 	  .spr_addr_i		(spr_addr),
 	  .spr_dat_i		(spr_write_dat),
 	  );*/
@@ -979,6 +980,7 @@ module mor1kx_ctrl_prontoespresso
 	    .clk			(clk),
 	    .rst			(rst),
 	    .irq_i			(irq_i[31:0]),
+	    .spr_access_i		(1'b1),			 // Templated
 	    .spr_we_i			(spr_we),		 // Templated
 	    .spr_addr_i			(spr_addr),		 // Templated
 	    .spr_dat_i			(spr_write_dat));	 // Templated
@@ -1014,6 +1016,7 @@ module mor1kx_ctrl_prontoespresso
 	  .spr_dat_o		(spr_internal_read_dat[10]),
 	  // Inputs
 	  .spr_we_i		(spr_we),
+          .spr_access_i         (1'b1),
 	  .spr_addr_i		(spr_addr),
 	  .spr_dat_i		(spr_write_dat),
 	  );*/
@@ -1027,6 +1030,7 @@ module mor1kx_ctrl_prontoespresso
 			  // Inputs
 			  .clk			(clk),
 			  .rst			(rst),
+			  .spr_access_i		(1'b1),		 // Templated
 			  .spr_we_i		(spr_we),	 // Templated
 			  .spr_addr_i		(spr_addr),	 // Templated
 			  .spr_dat_i		(spr_write_dat)); // Templated

--- a/rtl/verilog/mor1kx_decode.v
+++ b/rtl/verilog/mor1kx_decode.v
@@ -295,7 +295,7 @@ module mor1kx_decode
    assign decode_rfa_adr_o = decode_insn_i[`OR1K_RA_SELECT];
    assign decode_rfb_adr_o = decode_insn_i[`OR1K_RB_SELECT];
 
-   assign decode_rfd_adr_o = decode_op_jal_o ? 4'd9 :
+   assign decode_rfd_adr_o = decode_op_jal_o ? 5'd9 :
 			     decode_insn_i[`OR1K_RD_SELECT];
 
    // Immediate in l.mtspr is broken up, reassemble

--- a/rtl/verilog/mor1kx_decode.v
+++ b/rtl/verilog/mor1kx_decode.v
@@ -295,7 +295,7 @@ module mor1kx_decode
    assign decode_rfa_adr_o = decode_insn_i[`OR1K_RA_SELECT];
    assign decode_rfb_adr_o = decode_insn_i[`OR1K_RB_SELECT];
 
-   assign decode_rfd_adr_o = decode_op_jal_o ? 9 :
+   assign decode_rfd_adr_o = decode_op_jal_o ? 4'd9 :
 			     decode_insn_i[`OR1K_RD_SELECT];
 
    // Immediate in l.mtspr is broken up, reassemble

--- a/rtl/verilog/mor1kx_dmmu.v
+++ b/rtl/verilog/mor1kx_dmmu.v
@@ -141,7 +141,8 @@ endgenerate
    integer j;
    always @(*) begin
       tlb_miss_o = !tlb_reload_pagefault;
-      phys_addr_o = virt_addr_match_i[23:0];
+      phys_addr_o = {OPTION_OPERAND_WIDTH{1'b0}};
+      phys_addr_o[23:0] = virt_addr_match_i[23:0];
       ure = 0;
       uwe = 0;
       sre = 0;

--- a/rtl/verilog/mor1kx_dmmu.v
+++ b/rtl/verilog/mor1kx_dmmu.v
@@ -54,6 +54,8 @@ module mor1kx_dmmu
     output 				  spr_bus_ack_o
     );
 
+   localparam WAYS_WIDTH = (OPTION_DMMU_WAYS < 2) ? 1 : 2;
+
    wire [OPTION_OPERAND_WIDTH-1:0]    dtlb_match_dout[OPTION_DMMU_WAYS-1:0];
    wire [OPTION_DMMU_SET_WIDTH-1:0]   dtlb_match_addr;
    reg [OPTION_DMMU_WAYS-1:0]         dtlb_match_we;
@@ -87,8 +89,9 @@ module mor1kx_dmmu
    reg 				      dmmucr_spr_cs_r;
    reg [OPTION_OPERAND_WIDTH-1:0]     dmmucr;
 
-   wire [1:0]                         spr_way_idx;
-   reg [1:0]                          spr_way_idx_r;
+   wire [1:0] 			      spr_way_idx_full;
+   wire [WAYS_WIDTH-1:0] 	      spr_way_idx;
+   reg [WAYS_WIDTH-1:0] 	      spr_way_idx_r;
 
    wire [OPTION_DMMU_WAYS-1:0]        way_huge;
 
@@ -168,13 +171,13 @@ endgenerate
          dtlb_match_we[j] = 0;
          if (dtlb_match_reload_we)
            dtlb_match_we[j] = 1;
-         if (j == spr_way_idx)
+         if (j[WAYS_WIDTH-1:0] == spr_way_idx)
            dtlb_match_we[j] = dtlb_match_spr_cs & spr_bus_we_i;
 
          dtlb_trans_we[j] = 0;
          if (dtlb_trans_reload_we)
            dtlb_trans_we[j] = 1;
-         if (j == spr_way_idx)
+         if (j[WAYS_WIDTH-1:0] == spr_way_idx)
            dtlb_trans_we[j] = dtlb_trans_spr_cs & spr_bus_we_i;
       end
    end
@@ -184,7 +187,8 @@ endgenerate
 			!uwe & op_store_i || !ure & op_load_i) &
 			!tlb_reload_busy_o;
 
-   assign spr_way_idx = {spr_bus_addr_i[10], spr_bus_addr_i[8]};
+   assign spr_way_idx_full = {spr_bus_addr_i[10], spr_bus_addr_i[8]};
+   assign spr_way_idx = spr_way_idx_full[WAYS_WIDTH-1:0];
 
    always @(posedge clk `OR_ASYNC_RST)
      if (rst) begin

--- a/rtl/verilog/mor1kx_execute_alu.v
+++ b/rtl/verilog/mor1kx_execute_alu.v
@@ -627,6 +627,7 @@ endgenerate
 	 wire [OPTION_OPERAND_WIDTH-1:0] shift_right;
 	 wire [OPTION_OPERAND_WIDTH-1:0] shift_lsw;
 	 wire [OPTION_OPERAND_WIDTH-1:0] shift_msw;
+	 wire [OPTION_OPERAND_WIDTH*2-1:0] shift_wide;
 
 	 //
 	 // Bit-reverse on left shift, perform right shift,
@@ -637,7 +638,8 @@ endgenerate
 			    {OPTION_OPERAND_WIDTH{a[OPTION_OPERAND_WIDTH-1]}} :
 			    op_ror ? a : {OPTION_OPERAND_WIDTH{1'b0}};
 
-	 assign shift_right = {shift_msw, shift_lsw} >> b[4:0];
+	 assign shift_wide = {shift_msw, shift_lsw} >> b[4:0];
+	 assign shift_right = shift_wide[OPTION_OPERAND_WIDTH-1:0];
 	 assign shift_result = op_sll ? reverse(shift_right) : shift_right;
 
          assign shift_valid = 1;

--- a/rtl/verilog/mor1kx_execute_alu.v
+++ b/rtl/verilog/mor1kx_execute_alu.v
@@ -385,7 +385,7 @@ endgenerate
 
    // One signed overflow detection for all multiplication implmentations
    assign mul_signed_overflow = (FEATURE_MULTIPLIER=="NONE") ||
-				(FEATURE_MULTIPLIER=="PIPELINED") ? 0 :
+				(FEATURE_MULTIPLIER=="PIPELINED") ? 1'b0 :
 				// Same signs, check for negative result
 				// (should be positive)
 				((a[OPTION_OPERAND_WIDTH-1] ==
@@ -423,11 +423,11 @@ endgenerate
                div_count <= 0;
             end else if (decode_valid_i & op_div_i) begin
                div_done <= 0;
-               div_count <= OPTION_OPERAND_WIDTH;
+               div_count <= OPTION_OPERAND_WIDTH[5:0];
             end else if (div_count == 1)
                div_done <= 1;
             else if (!div_done)
-               div_count <= div_count - 1;
+               div_count <= div_count - 1'd1;
 
          always @(posedge clk) begin
             if (decode_valid_i & op_div_i) begin

--- a/rtl/verilog/mor1kx_immu.v
+++ b/rtl/verilog/mor1kx_immu.v
@@ -55,6 +55,8 @@ module mor1kx_immu
     output 				  spr_bus_ack_o
     );
 
+   localparam WAYS_WIDTH = (OPTION_IMMU_WAYS < 2) ? 1 : 2;
+
    wire [OPTION_OPERAND_WIDTH-1:0]    itlb_match_dout[OPTION_IMMU_WAYS-1:0];
    wire [OPTION_IMMU_SET_WIDTH-1:0]   itlb_match_addr;
    reg [OPTION_IMMU_WAYS-1:0]         itlb_match_we;
@@ -88,8 +90,9 @@ module mor1kx_immu
    reg 				      immucr_spr_cs_r;
    reg [OPTION_OPERAND_WIDTH-1:0]     immucr;
 
-   wire [1:0]                         spr_way_idx;
-   reg [1:0]                          spr_way_idx_r;
+   wire [1:0] 			      spr_way_idx_full;
+   wire [WAYS_WIDTH-1:0] 	      spr_way_idx;
+   reg [WAYS_WIDTH-1:0] 	      spr_way_idx_r;
 
    wire [OPTION_IMMU_WAYS-1:0]        way_huge;
 
@@ -169,13 +172,13 @@ endgenerate
          itlb_match_we[j] = 0;
          if (itlb_match_reload_we & !tlb_reload_huge)
            itlb_match_we[j] = 1;
-         if (j == spr_way_idx)
+         if (j[WAYS_WIDTH-1:0] == spr_way_idx)
            itlb_match_we[j] = itlb_match_spr_cs & spr_bus_we_i & !spr_bus_ack;
 
          itlb_trans_we[j] = 0;
          if (itlb_trans_reload_we & !tlb_reload_huge)
            itlb_trans_we[j] = 1;
-         if (j == spr_way_idx)
+         if (j[WAYS_WIDTH-1:0] == spr_way_idx)
            itlb_trans_we[j] = itlb_trans_spr_cs & spr_bus_we_i & !spr_bus_ack;
       end
    end
@@ -187,7 +190,8 @@ endgenerate
 		    (itlb_match_spr_cs_r | itlb_trans_spr_cs_r) &
 		    spr_bus_ack & !spr_bus_ack_r) & enable_i;
 
-   assign spr_way_idx = {spr_bus_addr_i[10], spr_bus_addr_i[8]};
+   assign spr_way_idx_full = {spr_bus_addr_i[10], spr_bus_addr_i[8]};
+   assign spr_way_idx = spr_way_idx_full[WAYS_WIDTH-1:0];
 
    always @(posedge clk `OR_ASYNC_RST)
      if (rst) begin

--- a/rtl/verilog/mor1kx_immu.v
+++ b/rtl/verilog/mor1kx_immu.v
@@ -148,7 +148,8 @@ endgenerate
    integer j;
    always @(*) begin
       tlb_miss_o = !tlb_reload_pagefault & !busy_o;
-      phys_addr_o = virt_addr_match_i[23:0];
+      phys_addr_o = {OPTION_OPERAND_WIDTH{1'b0}};
+      phys_addr_o[23:0] = virt_addr_match_i[23:0];
       sxe = 0;
       uxe = 0;
       cache_inhibit_o = 0;

--- a/rtl/verilog/mor1kx_lsu_cappuccino.v
+++ b/rtl/verilog/mor1kx_lsu_cappuccino.v
@@ -143,6 +143,7 @@ module mor1kx_lsu_cappuccino
    wire				     lsu_ack;
 
    wire 			     dc_ack;
+   wire 			     dc_err;
    wire [31:0] 			     dc_ldat;
    wire [31:0] 			     dc_sdat;
    wire [31:0] 			     dc_adr;
@@ -151,6 +152,7 @@ module mor1kx_lsu_cappuccino
    wire [3:0] 			     dc_bsel;
 
    wire 			     dc_access;
+   wire 			     dc_hit;
    wire 			     dc_refill_allowed;
    wire 			     dc_refill;
    wire 			     dc_refill_req;
@@ -692,6 +694,7 @@ if (FEATURE_DATACACHE!="NONE") begin : dcache_gen
 	    .refill_o			(dc_refill),
 	    .refill_req_o		(dc_refill_req),
 	    .refill_done_o		(dc_refill_done),
+            .cache_hit_o                (dc_hit),
 	    .cpu_err_o			(dc_err),
 	    .cpu_ack_o			(dc_ack),
 	    .cpu_dat_o			(dc_ldat),
@@ -732,7 +735,7 @@ if (FEATURE_DATACACHE!="NONE") begin : dcache_gen
 	    .refill_o			(dc_refill),		 // Templated
 	    .refill_req_o		(dc_refill_req),	 // Templated
 	    .refill_done_o		(dc_refill_done),	 // Templated
-	    .cache_hit_o		(dc_hit_o),
+	    .cache_hit_o		(dc_hit),		 // Templated
 	    .cpu_err_o			(dc_err),		 // Templated
 	    .cpu_ack_o			(dc_ack),		 // Templated
 	    .cpu_dat_o			(dc_ldat),		 // Templated
@@ -767,6 +770,7 @@ end else begin
    assign dc_refill_done = 0;
    assign dc_refill_req = 0;
    assign dc_ack = 0;
+   assign dc_err = 0;
    assign dc_bsel = 0;
    assign dc_we = 0;
    assign dc_snoop_hit = 0;

--- a/rtl/verilog/mor1kx_lsu_cappuccino.v
+++ b/rtl/verilog/mor1kx_lsu_cappuccino.v
@@ -142,13 +142,11 @@ module mor1kx_lsu_cappuccino
    wire [OPTION_OPERAND_WIDTH-1:0]   lsu_sdat;
    wire				     lsu_ack;
 
-   wire 			     dc_err;
    wire 			     dc_ack;
    wire [31:0] 			     dc_ldat;
    wire [31:0] 			     dc_sdat;
    wire [31:0] 			     dc_adr;
    wire [31:0] 			     dc_adr_match;
-   wire 			     dc_req;
    wire 			     dc_we;
    wire [3:0] 			     dc_bsel;
 
@@ -663,13 +661,13 @@ endgenerate
 			 {dmmu_phys_addr[OPTION_OPERAND_WIDTH-1:2],2'b0} :
 			 {ctrl_lsu_adr_i[OPTION_OPERAND_WIDTH-1:2],2'b0};
 
-   assign dc_req = ctrl_op_lsu & dc_access & !access_done & !dbus_stall &
-		   !(dbus_atomic & dbus_we & !atomic_reserve);
    assign dc_refill_allowed = !(ctrl_op_lsu_store_i | state == WRITE) &
 			      !dc_snoop_hit & !snoop_valid;
 
 generate
 if (FEATURE_DATACACHE!="NONE") begin : dcache_gen
+   wire dc_req = ctrl_op_lsu & dc_access & !access_done & !dbus_stall &
+		   !(dbus_atomic & dbus_we & !atomic_reserve);
    if (OPTION_DCACHE_LIMIT_WIDTH == OPTION_OPERAND_WIDTH) begin
       assign dc_access =  ctrl_op_lsu_store_i | dc_enabled &
 			 !(dmmu_cache_inhibit & dmmu_enable_i);
@@ -768,12 +766,12 @@ end else begin
    assign dc_refill = 0;
    assign dc_refill_done = 0;
    assign dc_refill_req = 0;
-   assign dc_err = 0;
    assign dc_ack = 0;
    assign dc_bsel = 0;
    assign dc_we = 0;
    assign dc_snoop_hit = 0;
    assign dc_hit_o = 0;
+   assign dc_ldat = 0;
 end
 
 endgenerate

--- a/rtl/verilog/mor1kx_pic.v
+++ b/rtl/verilog/mor1kx_pic.v
@@ -101,7 +101,7 @@ module mor1kx_pic
            begin: picsrlevelgenerate
               // PIC status register
               always @(*)
-                spr_picsr[irqline] <= irq_unmasked[irqline];
+                spr_picsr[irqline] = irq_unmasked[irqline];
            end
       end // if (OPTION_PIC_TRIGGER=="LEVEL")
 

--- a/rtl/verilog/mor1kx_rf_cappuccino.v
+++ b/rtl/verilog/mor1kx_rf_cappuccino.v
@@ -273,8 +273,11 @@ if (FEATURE_DEBUGUNIT!="NONE" || FEATURE_FASTCONTEXTS!="NONE" ||
    assign spr_gpr_ack_o = spr_gpr_we & !wb_rf_wb_i |
 			  spr_gpr_re & spr_gpr_read_ack;
 
+   wire [RF_ADDR_WIDTH-1:0] wb_rfd_adr_expand;
+   assign wb_rfd_adr_expand[RF_ADDR_WIDTH-1:OPTION_RF_ADDR_WIDTH] = 0;
+   assign wb_rfd_adr_expand[OPTION_RF_ADDR_WIDTH-1:0] = wb_rfd_adr_i;
    assign rf_wren =  wb_rf_wb_i | spr_gpr_we;
-   assign rf_wradr = wb_rf_wb_i ? wb_rfd_adr_i : spr_bus_addr_i;
+   assign rf_wradr = wb_rf_wb_i ? wb_rfd_adr_expand : spr_bus_addr_i[RF_ADDR_WIDTH-1:0];
    assign rf_wrdat = wb_rf_wb_i ? result_i : spr_bus_dat_i;
 
    // Zero-pad unused parts of vector

--- a/rtl/verilog/mor1kx_store_buffer.v
+++ b/rtl/verilog/mor1kx_store_buffer.v
@@ -61,7 +61,7 @@ module mor1kx_store_buffer
      if (rst)
        write_pointer <= 0;
      else if (write_i)
-       write_pointer <= write_pointer + 1;
+       write_pointer <= write_pointer + 1'b1;
 
    always @(posedge clk `OR_ASYNC_RST)
      if (rst)

--- a/rtl/verilog/mor1kx_store_buffer.v
+++ b/rtl/verilog/mor1kx_store_buffer.v
@@ -61,13 +61,13 @@ module mor1kx_store_buffer
      if (rst)
        write_pointer <= 0;
      else if (write_i)
-       write_pointer <= write_pointer + 1'b1;
+       write_pointer <= write_pointer + 1'd1;
 
    always @(posedge clk `OR_ASYNC_RST)
      if (rst)
        read_pointer <= 0;
      else if (read_i)
-       read_pointer <= read_pointer + 1;
+       read_pointer <= read_pointer + 1'd1;
 
    mor1kx_simple_dpram_sclk
      #(


### PR DESCRIPTION
Hi,

those are linter fixes based on #44. One topic from there remains: parameter width inference, where I don't see a good solution for now.

I fixed all linter warnings with verilator and travis will check this in future: https://travis-ci.org/openrisc/mor1kx (to be replaced with LibreCores CI).

Cheers,
Stefan