### PR TITLE
Fix compiling on modelsim after iverilog fixes

### DIFF
--- a/rtl/verilog/mor1kx_cpu_cappuccino.v
+++ b/rtl/verilog/mor1kx_cpu_cappuccino.v
@@ -1129,9 +1129,9 @@ module mor1kx_cpu_cappuccino
 // synthesis translate_off
    /* Debug signals required for the debug monitor */
 
-   localparam RF_ADDR_WIDTH = mor1kx_rf_cappuccino.calc_rf_addr_width(
-                                OPTION_RF_ADDR_WIDTH,
-                                OPTION_RF_NUM_SHADOW_GPR);
+`include "mor1kx_utils.vh"
+   localparam RF_ADDR_WIDTH = calc_rf_addr_width(OPTION_RF_ADDR_WIDTH,
+                                                 OPTION_RF_NUM_SHADOW_GPR);
 
    function [OPTION_OPERAND_WIDTH-1:0] get_gpr;
       // verilator public

--- a/rtl/verilog/mor1kx_rf_cappuccino.v
+++ b/rtl/verilog/mor1kx_rf_cappuccino.v
@@ -76,14 +76,6 @@ module mor1kx_rf_cappuccino
     );
 
 `include "mor1kx_utils.vh"
-   function integer calc_rf_addr_width;
-      input integer rf_addr_width;
-      input integer rf_num_shadow_gpr;
-      calc_rf_addr_width  = rf_addr_width +
-                           ((rf_num_shadow_gpr == 1) ? 1 :
-                             `clog2(rf_num_shadow_gpr));
-   endfunction
-
    localparam RF_ADDR_WIDTH = calc_rf_addr_width(OPTION_RF_ADDR_WIDTH,
                                                  OPTION_RF_NUM_SHADOW_GPR);
 

--- a/rtl/verilog/mor1kx_utils.vh
+++ b/rtl/verilog/mor1kx_utils.vh
@@ -90,3 +90,18 @@ begin
 	end
 end
 endfunction
+
+//
+// Calculate register file address width, considers shadow registers, used in
+// rf and cpu.
+//
+function integer calc_rf_addr_width;
+input integer rf_addr_width;
+input integer rf_num_shadow_gpr;
+begin
+	calc_rf_addr_width = rf_addr_width + ((rf_num_shadow_gpr == 1) ? 1 :
+			`clog2(rf_num_shadow_gpr));
+end
+endfunction
+
+


### PR DESCRIPTION
The changes to get mor1kx compiling on iverilog seems to have broke
modelsim:

  External function 'mor1kx_rf_cappuccino.calc_rf_addr_width' may not be
  used in a constant expression.

To fix this (hopefully once and for all), I move the function out to the
mor1kx_utils.vh instead of calling it via internal references.