### PR TITLE
readme: Update docs on CACHE WIDTH option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ as running Linux requires a setting different than the default value.*
 |OPTION_DCACHE_BLOCK_WIDTH|Specifies the address width of a cache block|5|`n`| |
 |OPTION_DCACHE_SET_WIDTH|Specifies the set address width|9|`n`| |
 |OPTION_DCACHE_WAYS|Specifies the number of blocks per set|2|`n`| |
-|OPTION_DCACHE_LIMIT_WIDTH|Specifies the maximum address width|32|`n`| |
+|OPTION_DCACHE_LIMIT_WIDTH|Specifies the maximum address width|32|`n`|`31` for Linux to allow uncached device access|
 |OPTION_DCACHE_SNOOP|Enable bus snooping for cache coherency|`NONE`|`ENABLED` `NONE`|Linux SMP|
 |FEATURE_INSTRUCTIONCACHE|Enable memory access instruction caching|`NONE`|`ENABLED` `NONE`| |
 |OPTION_ICACHE_BLOCK_WIDTH|Specifies the address width of a cache block|5|`n`| |


### PR DESCRIPTION
As discussed in IRC:

```
  12:39 < stekern> oetwi_: or1k can only dynamically control addresses to
        be cacheable/noncacheable when the mmu is enabled.
  12:40 < stekern> mor1kx have an option to work around this, you can
        hardwire the upper address space to be noncacheable by adjusting
        OPTION_DCACHE_LIMIT_WIDTH
  12:42 < stekern> (we should fix the linux kernel to setup some mmu
        mapping that marks the uart as non-cacheable before the first early
        prints)
```

We have traditionally set cache address width to 31 and mapped devices
into high order address space to avoid caching of device reads and
writes.  Add this as a recommendation in the mor1kx options
documentation.
  