### PR TITLE
Set unassigned bits in mmucfg SPRs

### DIFF
--- a/rtl/verilog/mor1kx_cfgrs.v
+++ b/rtl/verilog/mor1kx_cfgrs.v
@@ -133,7 +133,7 @@ module mor1kx_cfgrs
 
    /* Data MMU Configuration Register */
    /* Reserved */
-   assign spr_dmmucfgr[31:15] = 0;
+   assign spr_dmmucfgr[31:12] = 0;
    /* Hardware TLB Reload */
    assign spr_dmmucfgr[`OR1K_SPR_DMMUFGR_HTR] = 0;
    /* TLB Entry Invalidate Register Implemented */
@@ -153,7 +153,7 @@ module mor1kx_cfgrs
 
    /* Instruction MMU Configuration Register */
    /* Reserved */
-   assign spr_immucfgr[31:15] = 0;
+   assign spr_immucfgr[31:12] = 0;
    /* Hardware TLB Reload */
    assign spr_immucfgr[`OR1K_SPR_IMMUFGR_HTR] = 0;
    /* TLB Entry Invalidate Register Implemented */


### PR DESCRIPTION
The unassigned bits caused undefined values to spread through the design once MMU was enabled