### PR TITLE
true_dpram: Use a single sequential block

### DIFF
--- a/rtl/verilog/mor1kx_true_dpram_sclk.v
+++ b/rtl/verilog/mor1kx_true_dpram_sclk.v
@@ -16,13 +16,13 @@ module mor1kx_true_dpram_sclk
     parameter DATA_WIDTH = 32
     )
    (
-    input 		    clk,
+    input                   clk,
     input [ADDR_WIDTH-1:0]  addr_a,
-    input 		    we_a,
+    input                   we_a,
     input [DATA_WIDTH-1:0]  din_a,
     output [DATA_WIDTH-1:0] dout_a,
     input [ADDR_WIDTH-1:0]  addr_b,
-    input 		    we_b,
+    input                   we_b,
     input [DATA_WIDTH-1:0]  din_b,
     output [DATA_WIDTH-1:0] dout_b
     );
@@ -37,19 +37,17 @@ module mor1kx_true_dpram_sclk
 
    always @(posedge clk) begin
       if (we_a) begin
-	 mem[addr_a] <= din_a;
-	 rdata_a <= din_a;
+         mem[addr_a] <= din_a;
+         rdata_a <= din_a;
       end else begin
-	 rdata_a <= mem[addr_a];
+         rdata_a <= mem[addr_a];
       end
-   end
 
-   always @(posedge clk) begin
       if (we_b) begin
-	 mem[addr_b] <= din_b;
-	 rdata_b <= din_b;
+         mem[addr_b] <= din_b;
+         rdata_b <= din_b;
       end else begin
-	 rdata_b <= mem[addr_b];
+         rdata_b <= mem[addr_b];
       end
    end
 


### PR DESCRIPTION
Both Synopsys DC and Spyglass lint complain if multiple blocks are used,
even though the code should be functionally identical (at least from my
understanding).