### PR TITLE
Marocchino devel

### DIFF
--- a/bench/verilog/mor1kx_monitor.v
+++ b/bench/verilog/mor1kx_monitor.v
@@ -25,15 +25,14 @@
 `ifndef CPU_WRAPPER
  `define CPU_WRAPPER `MOR1KX_INST.mor1kx_cpu
 `endif
-`define CPU_INST `CPU_WRAPPER.`MOR1KX_CPU_PIPELINE.mor1kx_cpu
 `define EXECUTE_STAGE_INSN `CPU_WRAPPER.monitor_execute_insn
 `define EXECUTE_STAGE_ADV `CPU_WRAPPER.monitor_execute_advance
 `define CPU_clk `CPU_WRAPPER.monitor_clk
 `define CPU_FLAG `CPU_WRAPPER.monitor_flag
 `define CPU_SR `CPU_WRAPPER.monitor_spr_sr
 `define EXECUTE_PC `CPU_WRAPPER.monitor_execute_pc
-`define GPR_GET(x) `CPU_INST.get_gpr(x)
-`define GPR_SET(x, y) `CPU_INST.set_gpr(x, y)
+`define GPR_GET(x) `CPU_WRAPPER.get_gpr(x)
+`define GPR_SET(x, y) `CPU_WRAPPER.set_gpr(x, y)
 
 `include "mor1kx-defines.v"
 

--- a/mor1kx.core
+++ b/mor1kx.core
@@ -27,6 +27,7 @@ filesets:
       - rtl/verilog/mor1kx_decode_execute_cappuccino.v
       - rtl/verilog/mor1kx_decode.v
       - rtl/verilog/mor1kx_dmmu.v
+      - rtl/verilog/mor1kx_dpram_en_w1st.v
       - rtl/verilog/mor1kx_execute_alu.v
       - rtl/verilog/mor1kx_execute_ctrl_cappuccino.v
       - rtl/verilog/mor1kx_fetch_cappuccino.v

--- a/mor1kx.core
+++ b/mor1kx.core
@@ -1,0 +1,121 @@
+CAPI=2:
+
+name : ::mor1kx:5.0-r3
+#description : mor1kx - an OpenRISC processor IP core
+
+filesets:
+  core:
+    files:
+      - rtl/verilog/mor1kx-defines.v : {is_include_file : true}
+      - rtl/verilog/mor1kx-sprs.v : {is_include_file : true}
+      - rtl/verilog/mor1kx_utils.vh : {is_include_file : true}
+      - rtl/verilog/mor1kx_branch_predictor_gshare.v
+      - rtl/verilog/mor1kx_branch_predictor_simple.v
+      - rtl/verilog/mor1kx_branch_predictor_saturation_counter.v
+      - rtl/verilog/mor1kx_branch_prediction.v
+      - rtl/verilog/mor1kx_bus_if_wb32.v
+      - rtl/verilog/mor1kx_cache_lru.v
+      - rtl/verilog/mor1kx_cfgrs.v
+      - rtl/verilog/mor1kx_cpu_cappuccino.v
+      - rtl/verilog/mor1kx_cpu_espresso.v
+      - rtl/verilog/mor1kx_cpu_prontoespresso.v
+      - rtl/verilog/mor1kx_cpu.v
+      - rtl/verilog/mor1kx_ctrl_cappuccino.v
+      - rtl/verilog/mor1kx_ctrl_espresso.v
+      - rtl/verilog/mor1kx_ctrl_prontoespresso.v
+      - rtl/verilog/mor1kx_dcache.v
+      - rtl/verilog/mor1kx_decode_execute_cappuccino.v
+      - rtl/verilog/mor1kx_decode.v
+      - rtl/verilog/mor1kx_dmmu.v
+      - rtl/verilog/mor1kx_execute_alu.v
+      - rtl/verilog/mor1kx_execute_ctrl_cappuccino.v
+      - rtl/verilog/mor1kx_fetch_cappuccino.v
+      - rtl/verilog/mor1kx_fetch_espresso.v
+      - rtl/verilog/mor1kx_fetch_prontoespresso.v
+      - rtl/verilog/mor1kx_fetch_tcm_prontoespresso.v
+      - rtl/verilog/mor1kx_icache.v
+      - rtl/verilog/mor1kx_immu.v
+      - rtl/verilog/mor1kx_lsu_cappuccino.v
+      - rtl/verilog/mor1kx_lsu_espresso.v
+      - rtl/verilog/mor1kx_pcu.v
+      - rtl/verilog/mor1kx_pic.v
+      - rtl/verilog/mor1kx_rf_cappuccino.v
+      - rtl/verilog/mor1kx_rf_espresso.v
+      - rtl/verilog/mor1kx_simple_dpram_sclk.v
+      - rtl/verilog/mor1kx_store_buffer.v
+      - rtl/verilog/mor1kx_ticktimer.v
+      - rtl/verilog/mor1kx_true_dpram_sclk.v
+      - rtl/verilog/mor1kx.v
+      - rtl/verilog/mor1kx_wb_mux_cappuccino.v
+      - rtl/verilog/mor1kx_wb_mux_espresso.v
+      - rtl/verilog/mor1kx_bus_if_wb32_marocchino.v
+      - rtl/verilog/mor1kx_cache_lru_marocchino.v
+      - rtl/verilog/mor1kx_cpu_marocchino.v
+      - rtl/verilog/mor1kx_ctrl_marocchino.v
+      - rtl/verilog/mor1kx_dcache_marocchino.v
+      - rtl/verilog/mor1kx_decode_marocchino.v
+      - rtl/verilog/mor1kx_dmmu_marocchino.v
+      - rtl/verilog/mor1kx_execute_marocchino.v
+      - rtl/verilog/mor1kx_fetch_marocchino.v
+      - rtl/verilog/mor1kx_icache_marocchino.v
+      - rtl/verilog/mor1kx_immu_marocchino.v
+      - rtl/verilog/mor1kx_lsu_marocchino.v
+      - rtl/verilog/mor1kx_ocb_marocchino.v
+      - rtl/verilog/mor1kx_oman_marocchino.v
+      - rtl/verilog/mor1kx_pic_marocchino.v
+      - rtl/verilog/mor1kx_rf_marocchino.v
+      - rtl/verilog/mor1kx_ticktimer_marocchino.v
+      - rtl/verilog/mor1kx_top_marocchino.v
+    file_type : verilogSource
+
+  fpu:
+    files:
+      - rtl/verilog/pfpu32/pfpu32_addsub.v
+      - rtl/verilog/pfpu32/pfpu32_cmp.v
+      - rtl/verilog/pfpu32/pfpu32_f2i.v
+      - rtl/verilog/pfpu32/pfpu32_i2f.v
+      - rtl/verilog/pfpu32/pfpu32_muldiv.v
+      - rtl/verilog/pfpu32/pfpu32_rnd.v
+      - rtl/verilog/pfpu32/pfpu32_top.v
+    file_type : verilogSource
+
+  fpu_maroccino:
+    files:
+      - rtl/verilog/pfpu_marocchino/pfpu_addsub_marocchino.v
+      - rtl/verilog/pfpu_marocchino/pfpu_cmp_marocchino.v
+      - rtl/verilog/pfpu_marocchino/pfpu_div_marocchino.v
+      - rtl/verilog/pfpu_marocchino/pfpu_f2i_marocchino.v
+      - rtl/verilog/pfpu_marocchino/pfpu_i2f_marocchino.v
+      - rtl/verilog/pfpu_marocchino/pfpu_muldiv_marocchino.v
+      - rtl/verilog/pfpu_marocchino/pfpu_mul_marocchino.v
+      - rtl/verilog/pfpu_marocchino/pfpu_rnd_marocchino.v
+      - rtl/verilog/pfpu_marocchino/pfpu_top_marocchino.v
+    file_type : verilogSource
+
+  monitor:
+    files : [bench/verilog/mor1kx_monitor.v]
+    file_type : verilogSource
+
+parameters:
+  trace_enable:
+    datatype    : bool
+    description : Enable mor1kx instruction trace
+    paramtype   : plusarg
+
+  trace_to_screen:
+    datatype    : bool
+    description : Output mor1kx instruction trace to screen
+    paramtype   : plusarg
+
+targets:
+  default:
+    filesets:
+      - core
+      - fpu
+      - fpu_maroccino
+      - "tool_icarus? (monitor)"
+      - "tool_isim? (monitor)"
+      - "tool_modelsim? (monitor)"
+      - "tool_rivierapro? (monitor)"
+      - "tool_xsim? (monitor)"
+    parameters: [trace_enable, trace_to_screen]

--- a/rtl/verilog/mor1kx_cpu.v
+++ b/rtl/verilog/mor1kx_cpu.v
@@ -198,6 +198,34 @@ module mor1kx_cpu
    wire [OPTION_OPERAND_WIDTH-1:0]   monitor_spr_esr/* verilator public */;
    wire 			     monitor_branch_mispredict/* verilator public */;
 
+`ifndef SYNTHESIS
+   // synthesis translate_off
+   /* Provide interface hooks for register functions. */
+
+   function [OPTION_OPERAND_WIDTH-1:0] get_gpr;
+      // verilator public
+      input [15:0] gpr_num;
+      if (OPTION_CPU=="CAPPUCCINO")
+         get_gpr = cappuccino.mor1kx_cpu.get_gpr(gpr_num);
+      else if (OPTION_CPU=="ESPRESSO")
+         get_gpr = espresso.mor1kx_cpu.get_gpr(gpr_num);
+      else if (OPTION_CPU=="PRONTO_ESPRESSO")
+         get_gpr = prontoespresso.mor1kx_cpu.get_gpr(gpr_num);
+   endfunction
+
+   task set_gpr;
+      // verilator public
+      input [15:0] gpr_num;
+      input [OPTION_OPERAND_WIDTH-1:0] gpr_value;
+      if (OPTION_CPU=="CAPPUCCINO")
+         cappuccino.mor1kx_cpu.set_gpr(gpr_num, gpr_value);
+      else if (OPTION_CPU=="ESPRESSO")
+         espresso.mor1kx_cpu.set_gpr(gpr_num, gpr_value);
+      else if (OPTION_CPU=="PRONTO_ESPRESSO")
+         prontoespresso.mor1kx_cpu.set_gpr(gpr_num, gpr_value);
+   endtask
+   // synthesis translate_on
+`endif
 
    generate
       /* verilator lint_off WIDTH */

--- a/rtl/verilog/mor1kx_cpu_marocchino.v
+++ b/rtl/verilog/mor1kx_cpu_marocchino.v
@@ -563,6 +563,21 @@ module mor1kx_cpu_marocchino
   wire exec_an_except;
   reg  wrbk_an_except_r;
 
+  // Bench monitoring
+  wire [`OR1K_INSN_WIDTH-1:0] 	     monitor_execute_insn/* verilator public */;
+  wire 				     monitor_execute_advance/* verilator public */;
+  wire 				     monitor_flag_set/* verilator public */;
+  wire 				     monitor_flag_clear/* verilator public */;
+  wire 				     monitor_flag_sr/* verilator public */;
+  wire 				     monitor_flag/* verilator public */;
+  wire [OPTION_OPERAND_WIDTH-1:0]    monitor_spr_sr/* verilator public */;
+  wire [OPTION_OPERAND_WIDTH-1:0]    monitor_execute_pc/* verilator public */;
+  wire [OPTION_OPERAND_WIDTH-1:0]    monitor_rf_result_in/* verilator public */;
+  wire 				     monitor_clk/* verilator public */;
+  wire [OPTION_OPERAND_WIDTH-1:0]    monitor_spr_epcr/* verilator public */;
+  wire [OPTION_OPERAND_WIDTH-1:0]    monitor_spr_eear/* verilator public */;
+  wire [OPTION_OPERAND_WIDTH-1:0]    monitor_spr_esr/* verilator public */;
+  wire 				     monitor_branch_mispredict/* verilator public */;
 
   //----------------------------//
   // Instruction FETCH instance //
@@ -746,6 +761,62 @@ module mor1kx_cpu_marocchino
     .dcod_rfb1_jr_o                   (dcod_rfb1_jr) // RF
   );
 
+`ifndef SYNTHESIS
+// synthesis translate_off
+/* Debug signals required for the debug monitor */
+  assign monitor_flag = monitor_flag_set ? 1 :
+			monitor_flag_clear ? 0 :
+			monitor_flag_sr;
+  assign monitor_clk = cpu_clk;
+  assign monitor_execute_insn =u_fetch.fetch_insn_o;
+  assign monitor_execute_advance = u_oman.exec_valid_o;
+  assign monitor_flag_set = u_ctrl.wrbk_1clk_flag_set_i; 
+  assign monitor_flag_clear = u_ctrl.wrbk_1clk_flag_clear_i;
+  assign monitor_flag_sr = u_ctrl.ctrl_flag_sr_o;
+  assign monitor_spr_sr = {16'd0,u_ctrl.spr_sr[15:`OR1K_SPR_SR_F+1],
+			  // Use the locally calculated flag value
+			  monitor_flag,
+			  u_ctrl.spr_sr[`OR1K_SPR_SR_F-1:0]};
+  assign monitor_execute_pc = u_ctrl.spr_ppc;
+  assign monitor_rf_result_in = wrbk_result1;
+  assign monitor_spr_esr = {16'd0,u_ctrl.spr_esr};
+  assign monitor_spr_epcr = u_ctrl.spr_epcr;
+  assign monitor_spr_eear = u_ctrl.spr_eear;
+  assign monitor_branch_mispredict = 0;
+
+`include "mor1kx_utils.vh"
+   localparam RF_ADDR_WIDTH = calc_rf_addr_width(OPTION_RF_ADDR_WIDTH,
+                                                 OPTION_RF_NUM_SHADOW_GPR);
+
+   function [OPTION_OPERAND_WIDTH-1:0] get_gpr;
+      // verilator public
+      input [RF_ADDR_WIDTH-1:0] gpr_num;
+      begin
+	 // TODO: handle load ops
+	 if ((wrbk_rfd1_adr == gpr_num[4:0]) & wrbk_rfd1_we)
+	   get_gpr = wrbk_result1;
+	 else if ((wrbk_rfd2_adr == gpr_num[4:0]) & wrbk_rfd2_we)
+	   get_gpr = wrbk_result2;
+	 else
+	   get_gpr = u_rf.gpr0_rdata_bus[gpr_num];
+      end
+   endfunction //
+
+
+   task set_gpr;
+      // verilator public
+      input [RF_ADDR_WIDTH-1:0] gpr_num;
+      input [OPTION_OPERAND_WIDTH-1:0] gpr_value;
+      begin
+	 $display("Error: MAROCCHINO pipeline does not support set_gpr");
+	 $finish();
+	 // This doesnt work you can address a element generated in a for
+	 // loop.
+	 //u_rf.u_single_gpr[gpr_num].gpr_r = gpr_value;
+      end
+   endtask
+// synthesis translate_on
+`endif
 
   //--------//
   // DECODE //

--- a/rtl/verilog/mor1kx_top_marocchino.v
+++ b/rtl/verilog/mor1kx_top_marocchino.v
@@ -348,7 +348,7 @@ module mor1kx_top_marocchino
     .FEATURE_PSYNC                    (FEATURE_PSYNC), // CPU
     .FEATURE_CSYNC                    (FEATURE_CSYNC) // CPU
   )
-  u_cpu_marocchino
+  mor1kx_cpu
   (
     // Wishbone clock and reset
     .wb_clk                   (wb_clk), // CPU


### PR DESCRIPTION
This is a WIP to get marocchino working in the or1k-tests suite with mor1kx-generic.  You can see my repos for those.  This compiles now, but still some work to do.

Comments:
  - During this integration I found marocchino is almost a complete rewrite of mor1kx.  Should we just separate it out to a new repo i.e. openrisc/marocchino?  This will give it better exposure, and I am not so sure integrating it into mor1kx main will give it the credit it needs.
  - The main issues I see with integrating it is:
     1. It uses a different wb interconnect (i.e. so there are new signals from WB to the pipeline)
     2. It doesnt use the toplevel mor1kx module