### PR TITLE
Tap reporting of or1k-tests

### DIFF
--- a/.travis/run-or1k-tests.sh
+++ b/.travis/run-or1k-tests.sh
@@ -21,4 +21,7 @@ result=$?
 if [ $result != 0 ] ; then
   cat runtests.log
 fi
+
+cp $HOME/src/tools/or1k-tests/native/report.tap /src
+
 exit $result

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
                     }
                     steps {
                         dockerrun()
+                        tapReporting()
                     }
                 }
                 stage("testing 1") {
@@ -28,6 +29,7 @@ pipeline {
                     }
                     steps {
                         dockerrun()
+                        tapReporting()
                     }
                 }
                 stage("testing 2") {
@@ -40,6 +42,7 @@ pipeline {
                     }
                     steps {
                         dockerrun()
+                        tapReporting()
                     }
                 }
                 stage("testing 3") {
@@ -52,6 +55,7 @@ pipeline {
                     }
                     steps {
                         dockerrun()
+                        tapReporting()
                     }
                 }
                 stage("testing 4") {
@@ -64,6 +68,7 @@ pipeline {
                     }
                     steps {
                         dockerrun()
+                        tapReporting()
                     }
                 }
                 stage("testing 5") {
@@ -76,6 +81,7 @@ pipeline {
                     }
                     steps {
                         dockerrun()
+                        tapReporting()
                     }
                 }
                 stage("testing 6") {
@@ -88,6 +94,7 @@ pipeline {
                     }
                     steps {
                         dockerrun()
+                        tapReporting()
                     }
                 }
                 stage("testing 7") {
@@ -100,6 +107,7 @@ pipeline {
                     }
                     steps {
                         dockerrun()
+                        tapReporting()
                     }
                 }
                 stage("testing 8") {
@@ -112,6 +120,7 @@ pipeline {
                     }
                     steps {
                         dockerrun()
+                        tapReporting()
                     }
                 }
                 stage("testing 9") {
@@ -125,6 +134,7 @@ pipeline {
                             //TODO: remove try/catch once the failing test is fixed (https://github.com/openrisc/mor1kx/issues/71)
                             try {
                                 dockerrun()
+                                tapReporting()
                             } catch (Exception e) {
                                 echo "Allowed failure"
                             }
@@ -138,4 +148,8 @@ pipeline {
 
 void dockerrun() {
     sh 'docker run --rm -v $(pwd):/src -e "JOB=$JOB" -e "SIM=$SIM" -e "PIPELINE=$PIPELINE" -e "EXPECTED_FAILURES=$EXPECTED_FAILURES" -e "EXTRA_CORE_ARGS=$EXTRA_CORE_ARGS" librecores/librecores-ci-openrisc /src/.travis/test.sh'
+}
+
+void tapReporting() {
+    step([$class: "TapPublisher", testResults: "report.tap"])
 }


### PR DESCRIPTION
Create a Tap Reporting on Jenkins Instance ( https://ci.librecores.org/job/Projects/job/OpenRISC/ ) with the PR (https://github.com/openrisc/or1k-tests/pull/5), which  Create a new report.tap with test results written in TAP format. 


![TapReporting](https://user-images.githubusercontent.com/37153406/62421407-cfed7d00-b6be-11e9-98f5-71056b105546.png)

CC @oleg-nenashev @stffrdhrn 

