### PR TITLE
Fix mor1kx_decode to accept valid l.fl1 (l.ff1) instructions (#110)

### DIFF
--- a/rtl/verilog/mor1kx_decode.v
+++ b/rtl/verilog/mor1kx_decode.v
@@ -259,7 +259,9 @@ module mor1kx_decode
 			      opc_alu == `OR1K_ALU_OPC_SHRT ||
 			      opc_insn == `OR1K_OPCODE_SHRTI;
 
+   /* check bit 9 to verify valid l.fl1/l.ff1 instruction */
    assign decode_op_ffl1_o = opc_insn == `OR1K_OPCODE_ALU &&
+                             (decode_insn_i[9:8] == 2'b00 || decode_insn_i[9:8] == 2'b01) &&
 			     opc_alu == `OR1K_ALU_OPC_FFL1;
 
    assign decode_op_movhi_o = opc_insn == `OR1K_OPCODE_MOVHI;


### PR DESCRIPTION
* Fix mor1kx_decode to only accept valid l.fl1 and l.ff1 instructions

Both l.fl1 and l.ff1 have bit 9 set in the insruction as port of their op codes,
mor1kx_decode does not currently properly check this