### PR TITLE
Fix issues related to successive mtspr/mtspr instructions

### DIFF
--- a/rtl/verilog/mor1kx_dcache.v
+++ b/rtl/verilog/mor1kx_dcache.v
@@ -342,6 +342,9 @@ module mor1kx_dcache
     */
    integer w1;
    always @(posedge clk `OR_ASYNC_RST) begin
+      // The default is (of course) not to acknowledge the invalidate
+      invalidate_ack <= 1'b0;
+
       if (rst) begin
 	 state <= IDLE;
 	 write_pending <= 0;
@@ -377,7 +380,7 @@ module mor1kx_dcache
 		 // Store address in invalidate_adr that is muxed to the tag
 		 // memory write address
 		 invalidate_adr <= spr_bus_dat_i[WAY_WIDTH-1:OPTION_DCACHE_BLOCK_WIDTH];
-
+		 invalidate_ack <= 1'b1;
 		 // Change to invalidate state that actually accesses
 		 // the tag memory
 		 state <= INVALIDATE;
@@ -440,8 +443,10 @@ module mor1kx_dcache
 		 // Store address in invalidate_adr that is muxed to the tag
 		 // memory write address
 		 invalidate_adr <= spr_bus_dat_i[WAY_WIDTH-1:OPTION_DCACHE_BLOCK_WIDTH];
-
+		 invalidate_ack <= 1'b1;
 		 state <= INVALIDATE;
+	      end else if (cpu_we_i | write_pending) begin
+		 state <= WRITE;
 	      end else begin
 		 state <= IDLE;
 	      end
@@ -472,9 +477,6 @@ module mor1kx_dcache
 
       way_wr_dat = wrdat_i;
 
-      // The default is (of course) not to acknowledge the invalidate
-      invalidate_ack = 1'b0;
-
       if (snoop_hit) begin
 	 // This is the write access
 	 tag_we = 1'b1;
@@ -497,16 +499,6 @@ module mor1kx_dcache
 		      wradr_i[WAY_WIDTH-1:OPTION_DCACHE_BLOCK_WIDTH];
 
 	 case (state)
-	   IDLE: begin
-	      //
-	      // When idle we can always acknowledge the invalidate as it
-	      // has the highest priority in handling. When something is
-	      // changed on the state machine handling above this needs
-	      // to be changed.
-	      //
-	      invalidate_ack = 1'b1;
-	   end
-
 	   READ: begin
 	      if (hit) begin
 		 //
@@ -525,7 +517,7 @@ module mor1kx_dcache
 
 	   WRITE: begin
 	      way_wr_dat = cpu_dat_i;
-	      if (hit & cpu_req_i) begin
+	      if (hit & (cpu_req_i | write_pending)) begin
 		 /* Mux cache output with write data */
 		 if (!cpu_bsel_i[3])
 		   way_wr_dat[31:24] = cpu_dat_o[31:24];
@@ -536,9 +528,9 @@ module mor1kx_dcache
 		 if (!cpu_bsel_i[0])
 		   way_wr_dat[7:0] = cpu_dat_o[7:0];
 
-	      way_we = way_hit;
+		 way_we = way_hit;
 
-	      tag_lru_in = next_lru_history;
+		 tag_lru_in = next_lru_history;
 
 		 tag_we = 1'b1;
 	      end
@@ -586,8 +578,6 @@ module mor1kx_dcache
 	   end
 
 	   INVALIDATE: begin
-	      invalidate_ack = 1'b1;
-
 	      // Lazy invalidation, invalidate everything that matches tag address
               tag_lru_in = 0;
               for (w2 = 0; w2 < OPTION_DCACHE_WAYS; w2 = w2 + 1) begin

--- a/rtl/verilog/mor1kx_immu.v
+++ b/rtl/verilog/mor1kx_immu.v
@@ -174,13 +174,13 @@ endgenerate
          if (itlb_match_reload_we & !tlb_reload_huge)
            itlb_match_we[j] = 1;
          if (j[WAYS_WIDTH-1:0] == spr_way_idx)
-           itlb_match_we[j] = itlb_match_spr_cs & spr_bus_we_i & !spr_bus_ack;
+           itlb_match_we[j] = itlb_match_spr_cs & spr_bus_we_i & !itlb_match_spr_cs_r;
 
          itlb_trans_we[j] = 0;
          if (itlb_trans_reload_we & !tlb_reload_huge)
            itlb_trans_we[j] = 1;
          if (j[WAYS_WIDTH-1:0] == spr_way_idx)
-           itlb_trans_we[j] = itlb_trans_spr_cs & spr_bus_we_i & !spr_bus_ack;
+           itlb_trans_we[j] = itlb_trans_spr_cs & spr_bus_we_i & !itlb_trans_spr_cs_r;
       end
    end
 
@@ -231,16 +231,16 @@ endgenerate
    assign itlb_trans_spr_cs = spr_bus_stb_i & (spr_bus_addr_i[15:11] == 5'd2) &
                               |spr_bus_addr_i[10:9] & spr_bus_addr_i[7];
 
-   assign itlb_match_addr = itlb_match_spr_cs & !spr_bus_ack ?
+   assign itlb_match_addr = itlb_match_spr_cs & !itlb_match_spr_cs_r ?
 			    spr_bus_addr_i[OPTION_IMMU_SET_WIDTH-1:0] :
 			    virt_addr_i[13+(OPTION_IMMU_SET_WIDTH-1):13];
-   assign itlb_trans_addr = itlb_trans_spr_cs & !spr_bus_ack ?
+   assign itlb_trans_addr = itlb_trans_spr_cs & !itlb_trans_spr_cs_r ?
 			    spr_bus_addr_i[OPTION_IMMU_SET_WIDTH-1:0] :
 			    virt_addr_i[13+(OPTION_IMMU_SET_WIDTH-1):13];
 
-   assign itlb_match_din = itlb_match_spr_cs & spr_bus_we_i & !spr_bus_ack ?
+   assign itlb_match_din = itlb_match_spr_cs & spr_bus_we_i & !itlb_match_spr_cs_r ?
 			   spr_bus_dat_i : itlb_match_reload_din;
-   assign itlb_trans_din = itlb_trans_spr_cs & spr_bus_we_i & !spr_bus_ack ?
+   assign itlb_trans_din = itlb_trans_spr_cs & spr_bus_we_i & !itlb_trans_spr_cs_r ?
 			   spr_bus_dat_i : itlb_trans_reload_din;
 
    assign itlb_match_huge_addr = virt_addr_i[24+(OPTION_IMMU_SET_WIDTH-1):24];

--- a/rtl/verilog/mor1kx_lsu_cappuccino.v
+++ b/rtl/verilog/mor1kx_lsu_cappuccino.v
@@ -195,6 +195,7 @@ module mor1kx_lsu_cappuccino
    reg 				     dbus_atomic;
 
    reg 				     last_write;
+   // write_done indicates the store buffer has been flushed
    reg 				     write_done;
 
    // Atomic operations
@@ -363,11 +364,12 @@ module mor1kx_lsu_cappuccino
    assign store_buffer_ack = (FEATURE_STORE_BUFFER!="NONE") ?
 			     store_buffer_write :
 			     write_done;
-
+			     
+   // If we are writing we wait for the store buffer ack and
+   // in case of dcache being busy we wait for data cache ack too
    assign lsu_ack = (ctrl_op_lsu_store_i | state == WRITE) ?
-		    (store_buffer_ack & !ctrl_op_lsu_atomic_i |
-		     write_done & ctrl_op_lsu_atomic_i) :
-		    (dbus_access ? dbus_ack : dc_ack);
+                     (ctrl_op_lsu_atomic_i ? write_done : store_buffer_ack) :
+		     (dbus_access ? dbus_ack : dc_ack);
 
    assign lsu_ldat = dbus_access ? dbus_dat : dc_ldat;
    assign dbus_adr_o = dbus_adr;

--- a/rtl/verilog/mor1kx_lsu_cappuccino.v
+++ b/rtl/verilog/mor1kx_lsu_cappuccino.v
@@ -151,7 +151,6 @@ module mor1kx_lsu_cappuccino
    wire [3:0] 			     dc_bsel;
 
    wire 			     dc_access;
-   wire 			     dc_hit;
    wire 			     dc_refill_allowed;
    wire 			     dc_refill;
    wire 			     dc_refill_req;
@@ -736,7 +735,7 @@ if (FEATURE_DATACACHE!="NONE") begin : dcache_gen
 	    .refill_o			(dc_refill),		 // Templated
 	    .refill_req_o		(dc_refill_req),	 // Templated
 	    .refill_done_o		(dc_refill_done),	 // Templated
-	    .cache_hit_o		(dc_hit),		 // Templated
+	    .cache_hit_o		(dc_hit_o),		 // Templated
 	    .cpu_err_o			(dc_err),		 // Templated
 	    .cpu_ack_o			(dc_ack),		 // Templated
 	    .cpu_dat_o			(dc_ldat),		 // Templated


### PR DESCRIPTION
Issue #122

Writing to the tlb rams was dependent on the spr_bus_ack as a means
to only write during the first cycle after a spr_bus_stb_i.  This works
fine for a single write, but if we have a write to itlb_match_spr
followed by itlb_trans_spr the spr_bus_ack never goes low so the write
to itlb_trans_spr is skipped.

Fix this by using the itlb_match_spr_cs_r and itlb_trans_spr_cs_r
signals to control the "first cycle after spr_bus_stb_i" condition. This
way writes can happen independently.

Note, there may still be issues with a write to itlb_match followed by
another write to itlb_match.  Fixing that requires changing the "first
cycle after spr_bus_stb_i" policy, which is similar to dmmu.