### PR TITLE
icache: Don't allow invalidate on reset or error

### DIFF
--- a/rtl/verilog/mor1kx_icache.v
+++ b/rtl/verilog/mor1kx_icache.v
@@ -309,16 +309,17 @@ module mor1kx_icache
 	  state <= IDLE;
       endcase
 
-      if (invalidate_o & !refill) begin
+      if (rst) begin
+	 state <= IDLE;
+	 spr_bus_ack_o <= 0;
+      end else if (ic_imem_err_i)
+	 state <= IDLE;
+      else if (invalidate_o & !refill) begin
 	 invalidate_adr <= spr_bus_dat_i[WAY_WIDTH-1:OPTION_ICACHE_BLOCK_WIDTH];
 	 spr_bus_ack_o <= 1;
 	 state <= INVALIDATE;
       end
 
-      if (rst)
-	state <= IDLE;
-      else if(ic_imem_err_i)
-	state <= IDLE;
    end
 
    integer w2;


### PR DESCRIPTION
Issue: #127

The reset and error cases override the state to IDLE, we should
check invalidate after this to avoid setting the spr_bus_ack_o
when we are not going to invalidate.

This was detected via formal verification.