### PR TITLE
formal: Update ALU serial operations to time until complete

### DIFF
--- a/bench/formal/f_multiclock_op.v
+++ b/bench/formal/f_multiclock_op.v
@@ -1,0 +1,66 @@
+/* ****************************************************************************
+  This Source Code Form is subject to the terms of the
+  Open Hardware Description License, v. 1.0. If a copy
+  of the OHDL was not distributed with this file, You
+  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+
+  Description: mor1kx formal multiclock alu operation checker
+
+  Checks that an operation f_op_i finishes within a number of clock
+  cycles.  The completion of the operation is signaled by asserting
+  f_op_valid_i.  This is used to validate multi operation ALU operations
+  like multiply, divide and shift.
+
+  Copyright (C) 2021 Stafford Horne <shorne@gmail.com>
+
+***************************************************************************** */
+
+module f_multiclock_op
+#(
+  parameter STABLE_WIDTH = 32,
+  parameter OP_MAX_CLOCKS = 32
+ )
+ (
+  input clk,
+  input f_op_i,
+  input f_op_valid_i,
+  input decode_valid_i,
+  input [STABLE_WIDTH-1:0] f_stable_i,
+  input f_past_valid
+);
+
+   reg [5:0] f_op_count;
+   reg f_op;
+   initial f_op_count = 0;
+   initial f_op = 0;
+
+   //Valid multiplication output is seen after 32 clocks
+   always @(posedge clk) begin
+      if (f_past_valid) begin
+	  // If we have slow operations decode_valid will
+	  // go low to stall after the operation starts.
+	  if ($past(f_op_i))
+	     assume (!decode_valid_i);
+	  else
+	     assume (decode_valid_i);
+
+	  // Start counting when we see the operation start
+	  if ($rose(f_op_i)) begin
+	     f_op <= 1;
+	     f_op_count <= 1;
+	  end else if (f_op_valid_i) // Stop when the op is done
+	     f_op <= 0;
+
+	  if (f_op) begin
+	     f_op_count <= f_op_count + 1;
+	     assume (f_op_i);
+	     assume ($stable(f_stable_i));
+	  end
+
+	  // Ensure the operation completes never going beyond max count
+	  assert (f_op_count <= (OP_MAX_CLOCKS + 2));
+      end
+   end
+
+endmodule
+

--- a/bench/formal/mor1kx_cpu_cappuccino.sby
+++ b/bench/formal/mor1kx_cpu_cappuccino.sby
@@ -2,9 +2,10 @@
 RUN  icache  immu
 
 
+# We only check the first few cycles since we just confirm reset conditions
 [options]
 mode prove
-depth 20
+depth 5
 
 [engines]
 smtbmc yices
@@ -43,6 +44,7 @@ chparam -set FEATURE_INSTRUCTIONCACHE "ENABLED" mor1kx_cpu_cappuccino
 chparam -set FEATURE_IMMU "ENABLED" mor1kx_cpu_cappuccino
 chparam -set FEATURE_DMMU "ENABLED" mor1kx_cpu_cappuccino
 chparam -set FEATURE_DATACACHE "ENABLED" mor1kx_cpu_cappuccino
+chparam -set FEATURE_MULTIPLIER "SIMULATION" mor1kx_cpu_cappuccino
 
 prep -top mor1kx_cpu_cappuccino
 

--- a/bench/formal/mor1kx_execute_alu.sby
+++ b/bench/formal/mor1kx_execute_alu.sby
@@ -1,35 +1,41 @@
 [tasks]
 #Tags are not used in code but specify type of parameters set.
-test1  serial_mul        serial_div       serial_shift
-test2  pipelined_mul     simulation_div   barrel_shift
-test3  threestage_mul    none  _div       serial_div
-test4  simulation_mul    simulation_div   barrel_shift
+test_serial      serial_mul        serial_div       serial_shift
+test_pipe_mul    pipelined_mul     simulation_div   barrel_shift
+test_3stage_mul  threestage_mul    no_div           serial_shift
+test_sim_mul     simulation_mul    simulation_div   barrel_shift
 
+# Depth set to 64 to handle 32 cycle serial operations
+# For other tests no operations take more than 3 cycles so set
+# the depth to a conservative 10
 [options]
 mode prove
-depth 20
+depth 10
+
+test_serial: depth 64
 
 [engines]
 smtbmc yices
 
 [script]
+read -formal f_multiclock_op.v
 read -formal -D ALU mor1kx_execute_alu.v
 
-test1: chparam -set FEATURE_MULTIPLIER "SERIAL" mor1kx_execute_alu
-test1: chparam -set FEATURE_DIVIDER "SERIAL" mor1kx_execute_alu
-test1: chparam -set OPTION_SHIFTER "SERIAL" mor1kx_execute_alu
+test_serial: chparam -set FEATURE_MULTIPLIER "SERIAL" mor1kx_execute_alu
+test_serial: chparam -set FEATURE_DIVIDER "SERIAL" mor1kx_execute_alu
+test_serial: chparam -set OPTION_SHIFTER "SERIAL" mor1kx_execute_alu
 
-test2: chparam -set FEATURE_MULTIPLIER "PIPELINED" mor1kx_execute_alu
-test2: chparam -set FEATURE_DIVIDER "SIMULATION" mor1kx_execute_alu
-test2: chparam -set OPTION_SHIFTER "BARREL" mor1kx_execute_alu
+test_pipe_mul: chparam -set FEATURE_MULTIPLIER "PIPELINED" mor1kx_execute_alu
+test_pipe_mul: chparam -set FEATURE_DIVIDER "SIMULATION" mor1kx_execute_alu
+test_pipe_mul: chparam -set OPTION_SHIFTER "BARREL" mor1kx_execute_alu
 
-test3: chparam -set FEATURE_MULTIPLIER "THREESTAGE" mor1kx_execute_alu
-test3: chparam -set FEATURE_DIVIDER "NONE" mor1kx_execute_alu
-test3: chparam -set OPTION_SHIFTER "SERIAL" mor1kx_execute_alu
+test_3stage_mul: chparam -set FEATURE_MULTIPLIER "THREESTAGE" mor1kx_execute_alu
+test_3stage_mul: chparam -set FEATURE_DIVIDER "NONE" mor1kx_execute_alu
+test_3stage_mul: chparam -set OPTION_SHIFTER "SERIAL" mor1kx_execute_alu
 
-test4: chparam -set FEATURE_MULTIPLIER "SIMULATION" mor1kx_execute_alu
-test4: chparam -set FEATURE_DIVIDER "SIMULATION" mor1kx_execute_alu
-test4: chparam -set OPTION_SHIFTER "BARREL" mor1kx_execute_alu
+test_sim_mul: chparam -set FEATURE_MULTIPLIER "SIMULATION" mor1kx_execute_alu
+test_sim_mul: chparam -set FEATURE_DIVIDER "SIMULATION" mor1kx_execute_alu
+test_sim_mul: chparam -set OPTION_SHIFTER "BARREL" mor1kx_execute_alu
 
 chparam -set FEATURE_OVERFLOW "ENABLED" mor1kx_execute_alu
 
@@ -37,6 +43,7 @@ chparam -set FEATURE_OVERFLOW "ENABLED" mor1kx_execute_alu
 prep -top mor1kx_execute_alu
 
 [files]
+f_multiclock_op.v
 ../../rtl/verilog/mor1kx_execute_alu.v
 ../../rtl/verilog/mor1kx-defines.v
 ../../rtl/verilog/mor1kx-sprs.v

--- a/rtl/verilog/mor1kx_cpu_cappuccino.v
+++ b/rtl/verilog/mor1kx_cpu_cappuccino.v
@@ -1636,5 +1636,20 @@ module mor1kx_cpu_cappuccino
            $rose(spr_bus_ack_dc_i) || $rose(spr_bus_ack_ic_i)))
          assert (spr_bus_stb_o || $past(spr_bus_stb_o));
 
+   always @(*)
+      case (ibus_dat_i[`OR1K_ALU_OPC_SELECT])
+        `OR1K_ALU_OPC_ADDC,
+        `OR1K_ALU_OPC_ADD,
+        `OR1K_ALU_OPC_SUB,
+        `OR1K_ALU_OPC_MUL,
+        `OR1K_ALU_OPC_MULU,
+        `OR1K_ALU_OPC_DIV,
+        `OR1K_ALU_OPC_DIVU,
+        `OR1K_ALU_OPC_SHRT,
+        `OR1K_ALU_OPC_FFL1,
+        `OR1K_ALU_OPC_EXTBH,
+        `OR1K_ALU_OPC_EXTW:
+          assume (ibus_dat_i[`OR1K_OPCODE_SELECT] == `OR1K_OPCODE_ALU);
+      endcase
 `endif
 endmodule // mor1kx_cpu_cappuccino


### PR DESCRIPTION
The previous verification logic counted the cycles it took
to run a multipy operation stopping when it reached 30. then
confirming we were done.  The new logic is a bit more flexible and
simple we count until the operation is complete.  If the count goes
above 32 we fail.  This can be used for any multi clock multiply
operation so we use for 3 stage as well.

In the .sby file I have updated depth to 64 to allow k-indection to
capture a valid start of a multiply operation.  Also, I have changed
task names to be a bit more descriptive.