### PR TITLE
Formal: Update ALU Multiclock Interface

### DIFF
--- a/bench/formal/f_multiclock_op.v
+++ b/bench/formal/f_multiclock_op.v
@@ -39,7 +39,7 @@ module f_multiclock_op
       if (f_past_valid) begin
 	  // If we have slow operations decode_valid will
 	  // go low to stall after the operation starts.
-	  if ($past(f_op_i))
+	  if (f_op | f_op_valid_i)
 	     assume (!decode_valid_i);
 	  else
 	     assume (decode_valid_i);
@@ -58,9 +58,8 @@ module f_multiclock_op
 	  end
 
 	  // Ensure the operation completes never going beyond max count
-	  assert (f_op_count <= (OP_MAX_CLOCKS + 2));
+	  assert (f_op_count <= (OP_MAX_CLOCKS + 1));
       end
    end
-
 endmodule
 

--- a/bench/formal/mor1kx_execute_alu.sby
+++ b/bench/formal/mor1kx_execute_alu.sby
@@ -2,7 +2,7 @@
 #Tags are not used in code but specify type of parameters set.
 test_serial      serial_mul        serial_div       serial_shift
 test_pipe_mul    pipelined_mul     simulation_div   barrel_shift
-test_3stage_mul  threestage_mul    no_div           serial_shift
+test_3stage_mul  threestage_mul    no_div           barrel_shift
 test_sim_mul     simulation_mul    simulation_div   barrel_shift
 
 # Depth set to 64 to handle 32 cycle serial operations
@@ -31,13 +31,14 @@ test_pipe_mul: chparam -set OPTION_SHIFTER "BARREL" mor1kx_execute_alu
 
 test_3stage_mul: chparam -set FEATURE_MULTIPLIER "THREESTAGE" mor1kx_execute_alu
 test_3stage_mul: chparam -set FEATURE_DIVIDER "NONE" mor1kx_execute_alu
-test_3stage_mul: chparam -set OPTION_SHIFTER "SERIAL" mor1kx_execute_alu
+test_3stage_mul: chparam -set OPTION_SHIFTER "BARREL" mor1kx_execute_alu
 
 test_sim_mul: chparam -set FEATURE_MULTIPLIER "SIMULATION" mor1kx_execute_alu
 test_sim_mul: chparam -set FEATURE_DIVIDER "SIMULATION" mor1kx_execute_alu
 test_sim_mul: chparam -set OPTION_SHIFTER "BARREL" mor1kx_execute_alu
 
 chparam -set FEATURE_OVERFLOW "ENABLED" mor1kx_execute_alu
+chparam -set FEATURE_FFL1 "REGISTERED" mor1kx_execute_alu
 
 
 prep -top mor1kx_execute_alu


### PR DESCRIPTION
Previously, the test passed for serial checks of depth 10. We can correctly
validate serial operations only if the solver takes steps more than 40, and proof
should fail if we give depth less than OP_MAX_CLOCKS. Changing assumption
condition on decode_valid_i fixed this.

Also, Multi clock Interface has been used to verify FFL1.