### PR TITLE
Licence switch OHDL to CERN OHL-W V2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,370 +1,311 @@
-Open Hardware Description License Version 1.0
-(Based on the MPL 2.0 RC2)
-========================================================
-
-1. Definitions
---------------
-
-1.1. "Contributor"
-    means each individual or legal entity that creates, contributes to
-    the creation of, or owns a Covered Hardware Description.
-
-1.2. "Contributor Version"
-    means the combination of the Contributions of others (if any) used
-    by a Contributor and that particular Contributor's Contribution.
-
-1.3. "Contribution"
-    means Covered Hardware Description of a particular Contributor.
-
-1.4. "Covered Hardware Description"
-    means Source Code Form to which the initial Contributor has attached
-    the notice in Exhibit A, the Processed Form of such Source Code
-    Form, and Modifications of such Source Code Form, in each case
-    including portions thereof.
-
-1.5. "Incompatible With Secondary Licenses"
-    means that the initial Contributor has attached the notice described in
-    Exhibit B to the Covered Hardware Description
-
-1.6. "Processed Form"
-    means any form of the work other than Source Code Form.
-
-1.7. "Larger Work"
-    means a work that combines a Covered Hardware Description with code in a 
-    separate file or files not governed by the terms of this License.
-
-1.8. "License"
-    means this document.
-
-1.9. "Licensable"
-    means having the right to grant, to the maximum extent possible,
-    whether at the time of the initial grant or subsequently, any and
-    all of the rights conveyed by this License.
-
-1.10. "Modifications"
-    means any of the following:
-
-    (a) any file in Source Code Form that results from an addition to,
-        deletion from, or modification of the contents of a Covered
-        Hardware Description; or
+CERN Open Hardware Licence Version 2 - Weakly Reciprocal
 
-    (b) any new file in Source Code Form that contains any Covered
-        Hardware Description Source.
 
-1.11. "Patent Claims" of a Contributor
-    means any patent claim(s), including without limitation, method,
-    process, and apparatus claims, in any patent Licensable by such
-    Contributor that would be infringed, but for the grant of the
-    License, by the making, using, selling, offering for sale, having
-    made, import, or transfer of either its Contributions or its
-    Contributor Version.
+Preamble
 
-1.12. "Secondary License"
-    means either the GNU General Public License, Version 2.0 or later,
-    the GNU Lesser General Public License, Version 2.1 or later, or the
-    GNU Affero General Public License, Version 3.0 or later, or the
-    TAPR Open Hardware License, Version 1.0 or later, or the CERN OHL,
-    Verstion 1.1 or later.
+CERN has developed this licence to promote collaboration among
+hardware designers and to provide a legal tool which supports the
+freedom to use, study, modify, share and distribute hardware designs
+and products based on those designs. Version 2 of the CERN Open
+Hardware Licence comes in three variants: CERN-OHL-P (permissive); and
+two reciprocal licences: this licence, CERN-OHL-W (weakly reciprocal)
+and CERN-OHL-S (strongly reciprocal).
 
-1.13. "Source Code Form"
-    means the form of the work preferred for making modifications.
+The CERN-OHL-W is copyright CERN 2020. Anyone is welcome to use it, in
+unmodified form only.
 
-1.14. "You" (or "Your")
-    means an individual or a legal entity exercising rights under this
-    License. For legal entities, "You" includes any entity that
-    controls, is controlled by, or is under common control with You. For
-    purposes of this definition, "control" means (a) the power, direct
-    or indirect, to cause the direction or management of such entity,
-    whether by contract or otherwise, or (b) ownership of more than
-    fifty percent (50%) of the outstanding shares or beneficial
-    ownership of such entity.
+Use of this Licence does not imply any endorsement by CERN of any
+Licensor or their designs nor does it imply any involvement by CERN in
+their development.
 
-2. License Grants and Conditions
---------------------------------
 
-2.1. Grants
+1 Definitions
 
-Each Contributor hereby grants You a world-wide, royalty-free,
-non-exclusive license:
+  1.1 'Licence' means this CERN-OHL-W.
 
-(a) under intellectual property rights (other than patent or trademark)
-    Licensable by such Contributor to use, reproduce, make available,
-    modify, display, perform, distribute, and otherwise exploit its
-    Contributions, either on an unmodified basis, with Modifications, or
-    as part of a Larger Work; and
+  1.2 'Compatible Licence' means
 
-(b) under Patent Claims of such Contributor to make, use, sell, offer
-    for sale, have made, import, and otherwise transfer either its
-    Contributions or its Contributor Version.
-
-2.2. Effective Date
+       a) any earlier version of the CERN Open Hardware licence, or
 
-The licenses granted in Section 2.1 with respect to any Contribution
-become effective for each Contribution on the date the Contributor first
-distributes such Contribution.
+       b) any version of the CERN-OHL-S or the CERN-OHL-W, or
 
-2.3. Limitations on Grant Scope
+       c) any licence which permits You to treat the Source to which
+          it applies as licensed under CERN-OHL-S or CERN-OHL-W
+          provided that on Conveyance of any such Source, or any
+          associated Product You treat the Source in question as being
+          licensed under CERN-OHL-S or CERN-OHL-W as appropriate.
 
-The licenses granted in this Section 2 are the only rights granted under
-this License. No additional rights or licenses will be implied from the
-distribution or licensing of Covered Hardware Description under this License.
-Notwithstanding Section 2.1(b) above, no patent license is granted by a
-Contributor:
+  1.3 'Source' means information such as design materials or digital
+      code which can be applied to Make or test a Product or to
+      prepare a Product for use, Conveyance or sale, regardless of its
+      medium or how it is expressed. It may include Notices.
 
-(a) for any code that a Contributor has removed from Covered Hardware 
-    Description; or
+  1.4 'Covered Source' means Source that is explicitly made available
+      under this Licence.
 
-(b) for infringements caused by: (i) Your and any other third party's
-    modifications of a Covered Hardware Description, or (ii) the combination 
-    of its Contributions with other Source (except as part of its Contributor
-    Version); or
+  1.5 'Product' means any device, component, work or physical object,
+      whether in finished or intermediate form, arising from the use,
+      application or processing of Covered Source.
 
-(c) under Patent Claims infringed by a Covered Hardware Description in the 
-    absence of its Contributions.
-
-This License does not grant any rights in the trademarks, service marks,
-or logos of any Contributor (except as may be necessary to comply with
-the notice requirements in Section 3.4).
-
-2.4. Subsequent Licenses
-
-No Contributor makes additional grants as a result of Your choice to
-distribute the Covered Hardware Description under a subsequent version of this
-License (see Section 10.2) or under the terms of a Secondary License (if
-permitted under the terms of Section 3.3).
-
-2.5. Representation
-
-Each Contributor represents that the Contributor believes its
-Contributions are its original creation(s) or it has sufficient rights
-to grant the rights to its Contributions conveyed by this License.
-
-2.6. Fair Use
-
-This License is not intended to limit any rights You have under
-applicable copyright doctrines of fair use, fair dealing, or other
-equivalents.
-
-2.7. Conditions
-
-Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
-in Section 2.1.
-
-3. Responsibilities
--------------------
-
-3.1. Distribution of Source Form
-
-All distribution of Covered Hardware Description in Source Code Form, 
-including any Modifications that You create or to which You contribute, must be
-under the terms of this License. You must inform recipients that the Source
-Code Form of the Covered Hardware Description is governed by the terms of this
-License, and how they can obtain a copy of this License. You may not
-attempt to alter or restrict the recipients' rights in the Source Code
-Form.
-
-3.2. Distribution of Processed Form
-
-If You distribute Covered Hardware Description in Processed Form then:
-
-(a) such Covered Hardware Description must also be made available in Source 
-    Code Form, as described in Section 3.1, and You must inform recipients of
-    the Processed Form how they can obtain a copy of such Source Code
-    Form by reasonable means in a timely manner, at a charge no more
-    than the cost of distribution to the recipient; and
-
-(b) You may distribute such Processed Form under the terms of this
-    License, or sublicense it under different terms, provided that the
-    license for the Processed Form does not attempt to limit or alter
-    the recipients' rights in the Source Code Form under this License.
-
-3.3. Distribution of a Larger Work
-
-You may create and distribute a Larger Work under terms of Your choice,
-provided that You also comply with the requirements of this License for
-the Covered Hardware Description. If the Larger Work is a combination of a 
-Covered Hardware Description with a work governed by a Secondary License, and 
-the Covered Hardware Description is not Incompatible With Secondary Licenses, 
-this License permits You to additionally distribute such Covered Hardware 
-Description under the terms of that Secondary License, so that the recipient of
-the Larger Work may, at their option, further distribute the Covered Hardware 
-Description under the terms of either this License or that Secondary License.
-
-3.4. Notices
-
-You may not remove or alter the substance of any license notices
-(including copyright notices, patent notices, disclaimers of warranty,
-or limitations of liability) contained within the Source Code Form of
-the Covered Hardware Description, except that You may alter any license notices
-to the extent required to remedy known factual inaccuracies.
-
-3.5. Application of Additional Terms
-
-You may choose to offer, and to charge a fee for, warranty, support,
-indemnity or liability obligations to one or more recipients of a Covered
-Hardware Description. However, You may do so only on Your own behalf, and not 
-on behalf of any Contributor. You must make it absolutely clear that any
-such warranty, support, indemnity, or liability obligation is offered by
-You alone, and You hereby agree to indemnify every Contributor for any
-liability incurred by such Contributor as a result of warranty, support,
-indemnity or liability terms You offer. You may include additional
-disclaimers of warranty and limitations of liability specific to any
-jurisdiction.
-
-4. Inability to Comply Due to Statute or Regulation
----------------------------------------------------
-
-If it is impossible for You to comply with any of the terms of this
-License with respect to some or all of the Covered Hardware Description due to
-statute, judicial order, or regulation then You must: (a) comply with
-the terms of this License to the maximum extent possible; and (b)
-describe the limitations and the code they affect. Such description must
-be placed in a text file included with all distributions of the Covered
-Hardware Description under this License. Except to the extent prohibited by 
-statute or regulation, such description must be sufficiently detailed for a
-recipient of ordinary skill to be able to understand it.
-
-5. Termination
---------------
-
-5.1. The rights granted under this License will terminate automatically
-if You fail to comply with any of its terms. However, if You become
-compliant, then the rights granted under this License from a particular
-Contributor are reinstated (a) provisionally, unless and until such
-Contributor explicitly and finally terminates Your grants, and (b) on an
-ongoing basis, if such Contributor fails to notify You of the
-non-compliance by some reasonable means prior to 60 days after You have
-come back into compliance. Moreover, Your grants from a particular
-Contributor are reinstated on an ongoing basis if such Contributor
-notifies You of the non-compliance by some reasonable means, this is the
-first time You have received notice of non-compliance with this License
-from such Contributor, and You become compliant prior to 30 days after
-Your receipt of the notice.
-
-5.2. If You initiate litigation against any entity by asserting a patent
-infringement claim (excluding declaratory judgment actions,
-counter-claims, and cross-claims) alleging that a Contributor Version
-directly or indirectly infringes any patent, then the rights granted to
-You by any and all Contributors for the Covered Hardware Description under 
-Section 2.1 of this License shall terminate.
-
-5.3. In the event of termination under Sections 5.1 or 5.2 above, all
-end user license agreements (excluding distributors and resellers) which
-have been validly granted by You or Your distributors under this License
-prior to termination shall survive termination.
-
-************************************************************************
-*                                                                      *
-*  6. Disclaimer of Warranty                                           *
-*  -------------------------                                           *
-*                                                                      *
-*  The Covered Hardware Description is provided under this License on  *
-*  an "as is" basis, without warranty of any kind, either expressed,   *
-*  implied, or statutory, including, without limitation, warranties    *
-*  that the Covered Hardware Description is free of defects,           *
-*  merchantable, fit for a particular purpose or non-infringing. The   *
-*  entire risk as to the quality and performance of the Covered        *
-*  Hardware Description is with You. Should any Covered Hardware       *
-*  Description prove defective in any respect, You (not any            *
-*  Contributor) assume the cost of any necessary servicing, repair, or *
-*  correction. This disclaimer of warranty constitutes an essential    *
-*  part of this License. No use of any Covered Hardware Description is *
-*  authorized under this License except under this disclaimer.         *
-*                                                                      *
-************************************************************************
-
-************************************************************************
-*                                                                      *
-*  7. Limitation of Liability                                          *
-*  --------------------------                                          *
-*                                                                      *
-*  Under no circumstances and under no legal theory, whether tort      *
-*  (including negligence), contract, or otherwise, shall any           *
-*  Contributor, or anyone who distributes Covered Hardware Description *
-*  as permitted above, be liable to You for any direct, indirect,      *
-*  special, incidental, or consequential damages of any character      *
-*  including, without limitation, damages for lost profits, loss of    *
-*  goodwill, work stoppage, computer failure or malfunction, or any    *
-*  and all other commercial damages or losses, even if such party      *
-*  shall have been informed of the possibility of such damages. This   *
-*  limitation of liability shall not apply to liability for death or   *
-*  personal injury resulting from such party's negligence to the       *
-*  extent applicable law prohibits such limitation. Some               *
-*  jurisdictions do not allow the exclusion or limitation of           *
-*  incidental or consequential damages, so this exclusion and          *
-*  limitation may not apply to You.                                    *
-*                                                                      *
-************************************************************************
-
-8. Litigation
--------------
-
-Any litigation relating to this License may be brought only in the
-courts of a jurisdiction where the defendant maintains its principal
-place of business and such litigation shall be governed by laws of that
-jurisdiction, without reference to its conflict-of-law provisions.
-Nothing in this Section shall prevent a party's ability to bring
-cross-claims or counter-claims.
-
-9. Miscellaneous
-----------------
-
-This License represents the complete agreement concerning the subject
-matter hereof. If any provision of this License is held to be
-unenforceable, such provision shall be reformed only to the extent
-necessary to make it enforceable. Any law or regulation which provides
-that the language of a contract shall be construed against the drafter
-shall not be used to construe this License against a Contributor.
-
-10. Versions of the License
----------------------------
-
-10.1. New Versions
-
-Julius Baxter is the license steward. Except as provided in Section
-10.3, no one other than the license steward has the right to modify or
-publish new versions of this License. Each version will be given a
-distinguishing version number.
-
-10.2. Effect of New Versions
-
-You may distribute the Covered Hardware Description under the terms of the 
-version of the License under which You originally received the Covered Hardware
-Description, or under the terms of any subsequent version published by the 
-license steward.
-
-10.3. Modified Versions
-
-If you create designs not governed by this License, and you want to
-create a new license for such designs, you may create and use a
-modified version of this License if you rename the license and remove
-any references to the name of the license steward (except to note that
-such modified license differs from this License).
-
-10.4. Distributing Source Code Form that is Incompatible With Secondary
-Licenses
-
-If You choose to distribute Source Code Form that is Incompatible With
-Secondary Licenses under the terms of this version of the License, the
-notice described in Exhibit B of this License must be attached.
-
-Exhibit A - Source Code Form License Notice
--------------------------------------------
-
-  This Source Code Form is subject to the terms of the 
-  Open Hardware Description License, v. 1.0. If a copy 
-  of the OHDL was not distributed with this file, You 
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
-
-If it is not possible or desirable to put the notice in a particular
-file, then You may include the notice in a location (such as a LICENSE
-file in a relevant directory) where a recipient would be likely to look
-for such a notice.
-
-You may add additional accurate notices of copyright ownership.
-
-Exhibit B - "Incompatible With Secondary Licenses" Notice
----------------------------------------------------------
-
-  This Source Code Form is "Incompatible With Secondary Licenses", as
-  defined by the Open Hardware Description License, v. 1.0.
+  1.6 'Make' means to create or configure something, whether by
+      manufacture, assembly, compiling, loading or applying Covered
+      Source or another Product or otherwise.
+
+  1.7 'Available Component' means any part, sub-assembly, library or
+      code which:
+
+       a) is licensed to You as Complete Source under a Compatible
+          Licence; or
+
+       b) is available, at the time a Product or the Source containing
+          it is first Conveyed, to You and any other prospective
+          licensees
+
+           i) with sufficient rights and information (including any
+              configuration and programming files and information
+              about its characteristics and interfaces) to enable it
+              either to be Made itself, or to be sourced and used to
+              Make the Product; or
+          ii) as part of the normal distribution of a tool used to
+              design or Make the Product.
+
+  1.8 'External Material' means anything (including Source) which:
+
+       a) is only combined with Covered Source in such a way that it
+          interfaces with the Covered Source using a documented
+          interface which is described in the Covered Source; and
+
+       b) is not a derivative of or contains Covered Source, or, if it
+          is, it is solely to the extent necessary to facilitate such
+          interfacing.
+
+  1.9 'Complete Source' means the set of all Source necessary to Make
+      a Product, in the preferred form for making modifications,
+      including necessary installation and interfacing information
+      both for the Product, and for any included Available Components.
+      If the format is proprietary, it must also be made available in
+      a format (if the proprietary tool can create it) which is
+      viewable with a tool available to potential licensees and
+      licensed under a licence approved by the Free Software
+      Foundation or the Open Source Initiative. Complete Source need
+      not include the Source of any Available Component, provided that
+      You include in the Complete Source sufficient information to
+      enable a recipient to Make or source and use the Available
+      Component to Make the Product.
+
+ 1.10 'Source Location' means a location where a Licensor has placed
+      Covered Source, and which that Licensor reasonably believes will
+      remain easily accessible for at least three years for anyone to
+      obtain a digital copy.
+
+ 1.11 'Notice' means copyright, acknowledgement and trademark notices,
+      Source Location references, modification notices (subsection
+      3.3(b)) and all notices that refer to this Licence and to the
+      disclaimer of warranties that are included in the Covered
+      Source.
+
+ 1.12 'Licensee' or 'You' means any person exercising rights under
+      this Licence.
+
+ 1.13 'Licensor' means a natural or legal person who creates or
+      modifies Covered Source. A person may be a Licensee and a
+      Licensor at the same time.
+
+ 1.14 'Convey' means to communicate to the public or distribute.
+
+
+2 Applicability
+
+  2.1 This Licence governs the use, copying, modification, Conveying
+      of Covered Source and Products, and the Making of Products. By
+      exercising any right granted under this Licence, You irrevocably
+      accept these terms and conditions.
+
+  2.2 This Licence is granted by the Licensor directly to You, and
+      shall apply worldwide and without limitation in time.
+
+  2.3 You shall not attempt to restrict by contract or otherwise the
+      rights granted under this Licence to other Licensees.
+
+  2.4 This Licence is not intended to restrict fair use, fair dealing,
+      or any other similar right.
+
+
+3 Copying, Modifying and Conveying Covered Source
+
+  3.1 You may copy and Convey verbatim copies of Covered Source, in
+      any medium, provided You retain all Notices.
+
+  3.2 You may modify Covered Source, other than Notices, provided that
+      You irrevocably undertake to make that modified Covered Source
+      available from a Source Location should You Convey a Product in
+      circumstances where the recipient does not otherwise receive a
+      copy of the modified Covered Source. In each case subsection 3.3
+      shall apply.
+
+      You may only delete Notices if they are no longer applicable to
+      the corresponding Covered Source as modified by You and You may
+      add additional Notices applicable to Your modifications.
+
+  3.3 You may Convey modified Covered Source (with the effect that You
+      shall also become a Licensor) provided that You:
+
+       a) retain Notices as required in subsection 3.2;
+
+       b) add a Notice to the modified Covered Source stating that You
+          have modified it, with the date and brief description of how
+          You have modified it;
+
+       c) add a Source Location Notice for the modified Covered Source
+          if You Convey in circumstances where the recipient does not
+          otherwise receive a copy of the modified Covered Source; and
+
+       d) license the modified Covered Source under the terms and
+          conditions of this Licence (or, as set out in subsection
+          8.3, a later version, if permitted by the licence of the
+          original Covered Source). Such modified Covered Source must
+          be licensed as a whole, but excluding Available Components
+          contained in it or External Material to which it is
+          interfaced, which remain licensed under their own applicable
+          licences.
+
+
+4 Making and Conveying Products
+
+  4.1 You may Make Products, and/or Convey them, provided that You
+      either provide each recipient with a copy of the Complete Source
+      or ensure that each recipient is notified of the Source Location
+      of the Complete Source. That Complete Source includes Covered
+      Source and You must accordingly satisfy Your obligations set out
+      in subsection 3.3. If specified in a Notice, the Product must
+      visibly and securely display the Source Location on it or its
+      packaging or documentation in the manner specified in that
+      Notice.
+
+  4.2 Where You Convey a Product which incorporates External Material,
+      the Complete Source for that Product which You are required to
+      provide under subsection 4.1 need not include any Source for the
+      External Material.
+
+  4.3 You may license Products under terms of Your choice, provided
+      that such terms do not restrict or attempt to restrict any
+      recipients' rights under this Licence to the Covered Source.
+
+
+5 Research and Development
+
+You may Convey Covered Source, modified Covered Source or Products to
+a legal entity carrying out development, testing or quality assurance
+work on Your behalf provided that the work is performed on terms which
+prevent the entity from both using the Source or Products for its own
+internal purposes and Conveying the Source or Products or any
+modifications to them to any person other than You. Any modifications
+made by the entity shall be deemed to be made by You pursuant to
+subsection 3.2.
+
+
+6 DISCLAIMER AND LIABILITY
+
+  6.1 DISCLAIMER OF WARRANTY -- The Covered Source and any Products
+      are provided 'as is' and any express or implied warranties,
+      including, but not limited to, implied warranties of
+      merchantability, of satisfactory quality, non-infringement of
+      third party rights, and fitness for a particular purpose or use
+      are disclaimed in respect of any Source or Product to the
+      maximum extent permitted by law. The Licensor makes no
+      representation that any Source or Product does not or will not
+      infringe any patent, copyright, trade secret or other
+      proprietary right. The entire risk as to the use, quality, and
+      performance of any Source or Product shall be with You and not
+      the Licensor. This disclaimer of warranty is an essential part
+      of this Licence and a condition for the grant of any rights
+      granted under this Licence.
+
+  6.2 EXCLUSION AND LIMITATION OF LIABILITY -- The Licensor shall, to
+      the maximum extent permitted by law, have no liability for
+      direct, indirect, special, incidental, consequential, exemplary,
+      punitive or other damages of any character including, without
+      limitation, procurement of substitute goods or services, loss of
+      use, data or profits, or business interruption, however caused
+      and on any theory of contract, warranty, tort (including
+      negligence), product liability or otherwise, arising in any way
+      in relation to the Covered Source, modified Covered Source
+      and/or the Making or Conveyance of a Product, even if advised of
+      the possibility of such damages, and You shall hold the
+      Licensor(s) free and harmless from any liability, costs,
+      damages, fees and expenses, including claims by third parties,
+      in relation to such use.
+
+
+7 Patents
+
+  7.1 Subject to the terms and conditions of this Licence, each
+      Licensor hereby grants to You a perpetual, worldwide,
+      non-exclusive, no-charge, royalty-free, irrevocable (except as
+      stated in subsections 7.2 and 8.4) patent licence to Make, have
+      Made, use, offer to sell, sell, import, and otherwise transfer
+      the Covered Source and Products, where such licence applies only
+      to those patent claims licensable by such Licensor that are
+      necessarily infringed by exercising rights under the Covered
+      Source as Conveyed by that Licensor.
+
+  7.2 If You institute patent litigation against any entity (including
+      a cross-claim or counterclaim in a lawsuit) alleging that the
+      Covered Source or a Product constitutes direct or contributory
+      patent infringement, or You seek any declaration that a patent
+      licensed to You under this Licence is invalid or unenforceable
+      then any rights granted to You under this Licence shall
+      terminate as of the date such process is initiated.
+
+
+8 General
+
+  8.1 If any provisions of this Licence are or subsequently become
+      invalid or unenforceable for any reason, the remaining
+      provisions shall remain effective.
+
+  8.2 You shall not use any of the name (including acronyms and
+      abbreviations), image, or logo by which the Licensor or CERN is
+      known, except where needed to comply with section 3, or where
+      the use is otherwise allowed by law. Any such permitted use
+      shall be factual and shall not be made so as to suggest any kind
+      of endorsement or implication of involvement by the Licensor or
+      its personnel.
+
+  8.3 CERN may publish updated versions and variants of this Licence
+      which it considers to be in the spirit of this version, but may
+      differ in detail to address new problems or concerns. New
+      versions will be published with a unique version number and a
+      variant identifier specifying the variant. If the Licensor has
+      specified that a given variant applies to the Covered Source
+      without specifying a version, You may treat that Covered Source
+      as being released under any version of the CERN-OHL with that
+      variant. If no variant is specified, the Covered Source shall be
+      treated as being released under CERN-OHL-S. The Licensor may
+      also specify that the Covered Source is subject to a specific
+      version of the CERN-OHL or any later version in which case You
+      may apply this or any later version of CERN-OHL with the same
+      variant identifier published by CERN.
+
+      You may treat Covered Source licensed under CERN-OHL-W as
+      licensed under CERN-OHL-S if and only if all Available
+      Components referenced in the Covered Source comply with the
+      corresponding definition of Available Component for CERN-OHL-S.
+
+  8.4 This Licence shall terminate with immediate effect if You fail
+      to comply with any of its terms and conditions.
+
+  8.5 However, if You cease all breaches of this Licence, then Your
+      Licence from any Licensor is reinstated unless such Licensor has
+      terminated this Licence by giving You, while You remain in
+      breach, a notice specifying the breach and requiring You to cure
+      it within 30 days, and You have failed to come into compliance
+      in all material respects by the end of the 30 day period. Should
+      You repeat the breach after receipt of a cure notice and
+      subsequent reinstatement, this Licence will terminate
+      immediately and permanently. Section 6 shall continue to apply
+      after any termination.
+
+  8.6 This Licence shall not be enforceable except by a Licensor
+      acting as such, and third party beneficiary rights are
+      specifically excluded.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ build the HTML documentation, run the following in the [doc/](doc/) directory:
 This project is licensed under the CERN Open Hardware Licence Version 2 - Weakly Reciprocal (CERN-OHL-W). For
 details please see the [LICENSE](./LICENSE) file or https:/cern.ch/cern-ohl
 
+SPDX-License-Identifier: CERN-OHL-W-2.0
+
+https://spdx.org/licenses/CERN-OHL-W-2.0.html
+
 ## Configuration
 
 The mor1kx CPU is very configurable to allow you to customize the core to your

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ build the HTML documentation, run the following in the [doc/](doc/) directory:
 
 ## License
 
-This project is licensed under the Open Hardware Description License (OHDL). For
-details please see the [LICENSE](./LICENSE) file or http://juliusbaxter.net/ohdl/
+This project is licensed under the CERN Open Hardware Licence Version 2 - Weakly Reciprocal (CERN-OHL-W). For
+details please see the [LICENSE](./LICENSE) file or https:/cern.ch/cern-ohl
 
 ## Configuration
 

--- a/bench/formal/Makefile
+++ b/bench/formal/Makefile
@@ -1,8 +1,12 @@
 ###########################################################
-# This Source Code Form is subject to the terms of the
-# Open Hardware Description License, v. 1.0. If a copy
-# of the OHDL was not distributed with this file, You
-# can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+# This source describes Open Hardware and is licensed under the CERN-OHLW v2
+#
+# You may redistribute and modify this documentation and make products
+# using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+# This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+# WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+# AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+# for applicable conditions.
 #
 # Description: Simplistic makefile for running formal tests
 #

--- a/bench/formal/Makefile
+++ b/bench/formal/Makefile
@@ -1,12 +1,5 @@
 ###########################################################
-# This source describes Open Hardware and is licensed under the CERN-OHLW v2
-#
-# You may redistribute and modify this documentation and make products
-# using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-# This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-# WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-# AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-# for applicable conditions.
+# SPDX-License-Identifier: CERN-OHL-W-2.0
 #
 # Description: Simplistic makefile for running formal tests
 #

--- a/bench/formal/f_multiclock_op.v
+++ b/bench/formal/f_multiclock_op.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx formal multiclock alu operation checker
 

--- a/bench/formal/f_multiclock_op.v
+++ b/bench/formal/f_multiclock_op.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx formal multiclock alu operation checker
 

--- a/bench/formal/fspr_master.v
+++ b/bench/formal/fspr_master.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
   ***************************************************************************** */
 
  module fspr_master

--- a/bench/formal/fspr_master.v
+++ b/bench/formal/fspr_master.v
@@ -1,4 +1,15 @@
-module fspr_master
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
+  ***************************************************************************** */
+
+ module fspr_master
 #(
   parameter OPTION_OPERAND_WIDTH = 32
   )

--- a/bench/formal/fspr_slave.v
+++ b/bench/formal/fspr_slave.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
   ***************************************************************************** */
 
 module fspr_slave

--- a/bench/formal/fspr_slave.v
+++ b/bench/formal/fspr_slave.v
@@ -1,3 +1,14 @@
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
+  ***************************************************************************** */
+
 module fspr_slave
 #(
   parameter OPTION_OPERAND_WIDTH = 32,

--- a/bench/verilog/mor1kx_monitor.v
+++ b/bench/verilog/mor1kx_monitor.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the 
-  Open Hardware Description License, v. 1.0. If a copy 
-  of the OHDL was not distributed with this file, You 
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx monitor module
  

--- a/bench/verilog/mor1kx_monitor.v
+++ b/bench/verilog/mor1kx_monitor.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx monitor module
  

--- a/bench/verilog/mor1kx_traceport_monitor.v
+++ b/bench/verilog/mor1kx_traceport_monitor.v
@@ -1,3 +1,14 @@
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
+***************************************************************************** */
+
 `include "mor1kx-defines.v"
 
 `define OR1K_OPCODE_POS 31:26

--- a/bench/verilog/mor1kx_traceport_monitor.v
+++ b/bench/verilog/mor1kx_traceport_monitor.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 ***************************************************************************** */
 
 `include "mor1kx-defines.v"

--- a/rtl/verilog/mor1kx-defines.v
+++ b/rtl/verilog/mor1kx-defines.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx defines
 

--- a/rtl/verilog/mor1kx-defines.v
+++ b/rtl/verilog/mor1kx-defines.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx defines
 

--- a/rtl/verilog/mor1kx-sprs.v
+++ b/rtl/verilog/mor1kx-sprs.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: SPR definitions
 

--- a/rtl/verilog/mor1kx-sprs.v
+++ b/rtl/verilog/mor1kx-sprs.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: SPR definitions
 

--- a/rtl/verilog/mor1kx.v
+++ b/rtl/verilog/mor1kx.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx processor top level
 

--- a/rtl/verilog/mor1kx.v
+++ b/rtl/verilog/mor1kx.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx processor top level
 

--- a/rtl/verilog/mor1kx_branch_prediction.v
+++ b/rtl/verilog/mor1kx_branch_prediction.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Branch prediction module
   Generates a predicted flag output and compares that to the real flag

--- a/rtl/verilog/mor1kx_branch_prediction.v
+++ b/rtl/verilog/mor1kx_branch_prediction.v
@@ -1,17 +1,21 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description: Branch prediction module
- Generates a predicted flag output and compares that to the real flag
- when it comes back in the following pipeline stage.
- Signals are deliberately not named after the pipeline stage they belong to,
- in order to keep this module generic.
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2013 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
- Copyright (C) 2016 Alexey Baturo <baturo.alexey@gmail.com>
+  Description: Branch prediction module
+  Generates a predicted flag output and compares that to the real flag
+  when it comes back in the following pipeline stage.
+  Signals are deliberately not named after the pipeline stage they belong to,
+  in order to keep this module generic.
+
+  Copyright (C) 2013 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
+  Copyright (C) 2016 Alexey Baturo <baturo.alexey@gmail.com>
 
  ******************************************************************************/
 

--- a/rtl/verilog/mor1kx_branch_predictor_gshare.v
+++ b/rtl/verilog/mor1kx_branch_predictor_gshare.v
@@ -1,15 +1,19 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description: gshare branch predictor
- This predictor is based on array of FSMs with 4 states: strongly not taken,
- weakly not taken, weakly taken, strongly taken. Check saturation predictor.
- Index to the array of FSMs is built using xor of global history and lower bits of PC.
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2016 Alexey Baturo <baturo.alexey@gmail.com>
+  Description: gshare branch predictor
+  This predictor is based on array of FSMs with 4 states: strongly not taken,
+  weakly not taken, weakly taken, strongly taken. Check saturation predictor.
+  Index to the array of FSMs is built using xor of global history and lower bits of PC.
+
+  Copyright (C) 2016 Alexey Baturo <baturo.alexey@gmail.com>
 
  ******************************************************************************/
 

--- a/rtl/verilog/mor1kx_branch_predictor_gshare.v
+++ b/rtl/verilog/mor1kx_branch_predictor_gshare.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: gshare branch predictor
   This predictor is based on array of FSMs with 4 states: strongly not taken,

--- a/rtl/verilog/mor1kx_branch_predictor_saturation_counter.v
+++ b/rtl/verilog/mor1kx_branch_predictor_saturation_counter.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Saturating counter branch predictor
   This is FSM with 4 states: strongly not taken, weakly not taken,

--- a/rtl/verilog/mor1kx_branch_predictor_saturation_counter.v
+++ b/rtl/verilog/mor1kx_branch_predictor_saturation_counter.v
@@ -1,22 +1,26 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description: Saturating counter branch predictor
- This is FSM with 4 states: strongly not taken, weakly not taken,
- weakly taken, strongly taken.
- Fsm changes it state upon real(not predicted) flag.
- If flag was "true" and instruction was bf  or flag was "false" and
- instruction was bnf fsm changes its state towards "taken". And vice versa
- otherwise.
- We predict flag on current fsm state and current branch type.
- If we are in any "taken" state and current instruction is bf,
- we predict flag to be "true". Or we're in any "not taken" state and
- current instruction is bnf, we predict flag to be "true".
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2016 Alexey Baturo <baturo.alexey@gmail.com>
+  Description: Saturating counter branch predictor
+  This is FSM with 4 states: strongly not taken, weakly not taken,
+  weakly taken, strongly taken.
+  Fsm changes it state upon real(not predicted) flag.
+  If flag was "true" and instruction was bf  or flag was "false" and
+  instruction was bnf fsm changes its state towards "taken". And vice versa
+  otherwise.
+  We predict flag on current fsm state and current branch type.
+  If we are in any "taken" state and current instruction is bf,
+  we predict flag to be "true". Or we're in any "not taken" state and
+  current instruction is bnf, we predict flag to be "true".
+
+  Copyright (C) 2016 Alexey Baturo <baturo.alexey@gmail.com>
 
  ******************************************************************************/
 

--- a/rtl/verilog/mor1kx_branch_predictor_simple.v
+++ b/rtl/verilog/mor1kx_branch_predictor_simple.v
@@ -1,14 +1,18 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description: Simple branch predictor implementation
- We assume flag to be "true" if instruction is bf and it jumps backwords
- or if instruction is bnf and it jumps forward.
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2013 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
+  Description: Simple branch predictor implementation
+  We assume flag to be "true" if instruction is bf and it jumps backwords
+  or if instruction is bnf and it jumps forward.
+
+  Copyright (C) 2013 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
 
  ******************************************************************************/
 

--- a/rtl/verilog/mor1kx_branch_predictor_simple.v
+++ b/rtl/verilog/mor1kx_branch_predictor_simple.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Simple branch predictor implementation
   We assume flag to be "true" if instruction is bf and it jumps backwords

--- a/rtl/verilog/mor1kx_bus_if_wb32.v
+++ b/rtl/verilog/mor1kx_bus_if_wb32.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx processor Wishbone bus bridge
 

--- a/rtl/verilog/mor1kx_bus_if_wb32.v
+++ b/rtl/verilog/mor1kx_bus_if_wb32.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx processor Wishbone bus bridge
 

--- a/rtl/verilog/mor1kx_cache_lru.v
+++ b/rtl/verilog/mor1kx_cache_lru.v
@@ -1,12 +1,16 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description: Data cache LRU implementation
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2012 Stefan Wallentowitz <stefan.wallentowitz@tum.de>
+  Description: Data cache LRU implementation
+
+  Copyright (C) 2012 Stefan Wallentowitz <stefan.wallentowitz@tum.de>
 
  ******************************************************************************/
 

--- a/rtl/verilog/mor1kx_cache_lru.v
+++ b/rtl/verilog/mor1kx_cache_lru.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Data cache LRU implementation
 

--- a/rtl/verilog/mor1kx_cfgrs.v
+++ b/rtl/verilog/mor1kx_cfgrs.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx SPRs indicating configuration and version
 

--- a/rtl/verilog/mor1kx_cfgrs.v
+++ b/rtl/verilog/mor1kx_cfgrs.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx SPRs indicating configuration and version
 

--- a/rtl/verilog/mor1kx_cpu.v
+++ b/rtl/verilog/mor1kx_cpu.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: CPU wrapper module
 

--- a/rtl/verilog/mor1kx_cpu.v
+++ b/rtl/verilog/mor1kx_cpu.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: CPU wrapper module
 

--- a/rtl/verilog/mor1kx_cpu_cappuccino.v
+++ b/rtl/verilog/mor1kx_cpu_cappuccino.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: "Cappuccino" pipeline CPU module
 

--- a/rtl/verilog/mor1kx_cpu_cappuccino.v
+++ b/rtl/verilog/mor1kx_cpu_cappuccino.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: "Cappuccino" pipeline CPU module
 

--- a/rtl/verilog/mor1kx_cpu_espresso.v
+++ b/rtl/verilog/mor1kx_cpu_espresso.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: Espresso pipeline CPU module
 

--- a/rtl/verilog/mor1kx_cpu_espresso.v
+++ b/rtl/verilog/mor1kx_cpu_espresso.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Espresso pipeline CPU module
 

--- a/rtl/verilog/mor1kx_cpu_prontoespresso.v
+++ b/rtl/verilog/mor1kx_cpu_prontoespresso.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: "Pronto espresso" pipeline CPU module
 

--- a/rtl/verilog/mor1kx_cpu_prontoespresso.v
+++ b/rtl/verilog/mor1kx_cpu_prontoespresso.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: "Pronto espresso" pipeline CPU module
 

--- a/rtl/verilog/mor1kx_ctrl_cappuccino.v
+++ b/rtl/verilog/mor1kx_ctrl_cappuccino.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx control unit
 

--- a/rtl/verilog/mor1kx_ctrl_cappuccino.v
+++ b/rtl/verilog/mor1kx_ctrl_cappuccino.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx control unit
 

--- a/rtl/verilog/mor1kx_ctrl_espresso.v
+++ b/rtl/verilog/mor1kx_ctrl_espresso.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx espresso pipeline control unit
 

--- a/rtl/verilog/mor1kx_ctrl_espresso.v
+++ b/rtl/verilog/mor1kx_ctrl_espresso.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx espresso pipeline control unit
 

--- a/rtl/verilog/mor1kx_ctrl_prontoespresso.v
+++ b/rtl/verilog/mor1kx_ctrl_prontoespresso.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx pronto espresso pipeline control unit
 

--- a/rtl/verilog/mor1kx_ctrl_prontoespresso.v
+++ b/rtl/verilog/mor1kx_ctrl_prontoespresso.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx pronto espresso pipeline control unit
 

--- a/rtl/verilog/mor1kx_dcache.v
+++ b/rtl/verilog/mor1kx_dcache.v
@@ -1,14 +1,18 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description: Data cache implementation
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2012-2013
-    Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
-    Stefan Wallentowitz <stefan.wallentowitz@tum.de>
+  Description: Data cache implementation
+
+  Copyright (C) 2012-2013
+     Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
+     Stefan Wallentowitz <stefan.wallentowitz@tum.de>
 
  ******************************************************************************/
 

--- a/rtl/verilog/mor1kx_dcache.v
+++ b/rtl/verilog/mor1kx_dcache.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Data cache implementation
 

--- a/rtl/verilog/mor1kx_decode.v
+++ b/rtl/verilog/mor1kx_decode.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx decode unit
 

--- a/rtl/verilog/mor1kx_decode.v
+++ b/rtl/verilog/mor1kx_decode.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx decode unit
 

--- a/rtl/verilog/mor1kx_decode_execute_cappuccino.v
+++ b/rtl/verilog/mor1kx_decode_execute_cappuccino.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Cappuccino decode to execute module.
   - Decode to execute stage signal passing.

--- a/rtl/verilog/mor1kx_decode_execute_cappuccino.v
+++ b/rtl/verilog/mor1kx_decode_execute_cappuccino.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: Cappuccino decode to execute module.
   - Decode to execute stage signal passing.

--- a/rtl/verilog/mor1kx_dmmu.v
+++ b/rtl/verilog/mor1kx_dmmu.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Data MMU implementation
 

--- a/rtl/verilog/mor1kx_dmmu.v
+++ b/rtl/verilog/mor1kx_dmmu.v
@@ -1,12 +1,16 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description: Data MMU implementation
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2013 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
+  Description: Data MMU implementation
+
+  Copyright (C) 2013 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
 
  ******************************************************************************/
 

--- a/rtl/verilog/mor1kx_execute_alu.v
+++ b/rtl/verilog/mor1kx_execute_alu.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx execute stage ALU
 

--- a/rtl/verilog/mor1kx_execute_alu.v
+++ b/rtl/verilog/mor1kx_execute_alu.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx execute stage ALU
 

--- a/rtl/verilog/mor1kx_execute_ctrl_cappuccino.v
+++ b/rtl/verilog/mor1kx_execute_ctrl_cappuccino.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: execute to control stage signal passing
 

--- a/rtl/verilog/mor1kx_execute_ctrl_cappuccino.v
+++ b/rtl/verilog/mor1kx_execute_ctrl_cappuccino.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: execute to control stage signal passing
 

--- a/rtl/verilog/mor1kx_fetch_cappuccino.v
+++ b/rtl/verilog/mor1kx_fetch_cappuccino.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx fetch/address stage unit
 

--- a/rtl/verilog/mor1kx_fetch_cappuccino.v
+++ b/rtl/verilog/mor1kx_fetch_cappuccino.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx fetch/address stage unit
 

--- a/rtl/verilog/mor1kx_fetch_espresso.v
+++ b/rtl/verilog/mor1kx_fetch_espresso.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx espresso fetch unit
 

--- a/rtl/verilog/mor1kx_fetch_espresso.v
+++ b/rtl/verilog/mor1kx_fetch_espresso.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx espresso fetch unit
 

--- a/rtl/verilog/mor1kx_fetch_prontoespresso.v
+++ b/rtl/verilog/mor1kx_fetch_prontoespresso.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx pronto espresso fetch unit
 

--- a/rtl/verilog/mor1kx_fetch_prontoespresso.v
+++ b/rtl/verilog/mor1kx_fetch_prontoespresso.v
@@ -1,8 +1,12 @@
- /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx pronto espresso fetch unit
 

--- a/rtl/verilog/mor1kx_fetch_tcm_prontoespresso.v
+++ b/rtl/verilog/mor1kx_fetch_tcm_prontoespresso.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx pronto espresso fetch unit for TCM memories
 

--- a/rtl/verilog/mor1kx_fetch_tcm_prontoespresso.v
+++ b/rtl/verilog/mor1kx_fetch_tcm_prontoespresso.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx pronto espresso fetch unit for TCM memories
 

--- a/rtl/verilog/mor1kx_icache.v
+++ b/rtl/verilog/mor1kx_icache.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Instruction cache implementation
 

--- a/rtl/verilog/mor1kx_icache.v
+++ b/rtl/verilog/mor1kx_icache.v
@@ -1,14 +1,18 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description: Instruction cache implementation
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2012-2013
-    Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
-    Stefan Wallentowitz <stefan.wallentowitz@tum.de>
+  Description: Instruction cache implementation
+
+  Copyright (C) 2012-2013
+     Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
+     Stefan Wallentowitz <stefan.wallentowitz@tum.de>
 
  ******************************************************************************/
 

--- a/rtl/verilog/mor1kx_immu.v
+++ b/rtl/verilog/mor1kx_immu.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Instruction MMU implementation
 

--- a/rtl/verilog/mor1kx_immu.v
+++ b/rtl/verilog/mor1kx_immu.v
@@ -1,12 +1,16 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description: Instruction MMU implementation
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2013 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
+  Description: Instruction MMU implementation
+
+  Copyright (C) 2013 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
 
  ******************************************************************************/
 

--- a/rtl/verilog/mor1kx_lsu_cappuccino.v
+++ b/rtl/verilog/mor1kx_lsu_cappuccino.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description:  Data bus interface
 

--- a/rtl/verilog/mor1kx_lsu_cappuccino.v
+++ b/rtl/verilog/mor1kx_lsu_cappuccino.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description:  Data bus interface
 

--- a/rtl/verilog/mor1kx_lsu_espresso.v
+++ b/rtl/verilog/mor1kx_lsu_espresso.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description:  Load, store unit for espresso pipeline
 

--- a/rtl/verilog/mor1kx_lsu_espresso.v
+++ b/rtl/verilog/mor1kx_lsu_espresso.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description:  Load, store unit for espresso pipeline
 

--- a/rtl/verilog/mor1kx_pcu.v
+++ b/rtl/verilog/mor1kx_pcu.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx Perfomance Counters Unit
 

--- a/rtl/verilog/mor1kx_pcu.v
+++ b/rtl/verilog/mor1kx_pcu.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx Perfomance Counters Unit
 

--- a/rtl/verilog/mor1kx_pic.v
+++ b/rtl/verilog/mor1kx_pic.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: mor1kx PIC
 

--- a/rtl/verilog/mor1kx_pic.v
+++ b/rtl/verilog/mor1kx_pic.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx PIC
 

--- a/rtl/verilog/mor1kx_rf_cappuccino.v
+++ b/rtl/verilog/mor1kx_rf_cappuccino.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: Register file for cappuccino pipeline
   Handles reading the register file rams and register bypassing.

--- a/rtl/verilog/mor1kx_rf_cappuccino.v
+++ b/rtl/verilog/mor1kx_rf_cappuccino.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Register file for cappuccino pipeline
   Handles reading the register file rams and register bypassing.

--- a/rtl/verilog/mor1kx_rf_espresso.v
+++ b/rtl/verilog/mor1kx_rf_espresso.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Register file for espresso pipeline
 

--- a/rtl/verilog/mor1kx_rf_espresso.v
+++ b/rtl/verilog/mor1kx_rf_espresso.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: Register file for espresso pipeline
 

--- a/rtl/verilog/mor1kx_simple_dpram_sclk.v
+++ b/rtl/verilog/mor1kx_simple_dpram_sclk.v
@@ -1,14 +1,18 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description:
- Simple single clocked dual port ram (separate read and write ports),
- with optional bypass logic.
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2012 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
+  Description:
+  Simple single clocked dual port ram (separate read and write ports),
+  with optional bypass logic.
+
+  Copyright (C) 2012 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
 
  ******************************************************************************/
 

--- a/rtl/verilog/mor1kx_simple_dpram_sclk.v
+++ b/rtl/verilog/mor1kx_simple_dpram_sclk.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description:
   Simple single clocked dual port ram (separate read and write ports),

--- a/rtl/verilog/mor1kx_store_buffer.v
+++ b/rtl/verilog/mor1kx_store_buffer.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: Store buffer
   Currently a simple single clock FIFO, but with the ambition to

--- a/rtl/verilog/mor1kx_store_buffer.v
+++ b/rtl/verilog/mor1kx_store_buffer.v
@@ -1,14 +1,18 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description: Store buffer
- Currently a simple single clock FIFO, but with the ambition to
- have combining and reordering capabilities in the future.
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2013 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
+  Description: Store buffer
+  Currently a simple single clock FIFO, but with the ambition to
+  have combining and reordering capabilities in the future.
+
+  Copyright (C) 2013 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
 
  ******************************************************************************/
 `include "mor1kx-defines.v"

--- a/rtl/verilog/mor1kx_ticktimer.v
+++ b/rtl/verilog/mor1kx_ticktimer.v
@@ -1,14 +1,18 @@
 /* ****************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description: mor1kx tick timer unit
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2012 Authors
+  Description: mor1kx tick timer unit
 
- Author(s): Julius Baxter <juliusbaxter@gmail.com>
+  Copyright (C) 2012 Authors
+
+  Author(s): Julius Baxter <juliusbaxter@gmail.com>
 
 ***************************************************************************** */
 

--- a/rtl/verilog/mor1kx_ticktimer.v
+++ b/rtl/verilog/mor1kx_ticktimer.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: mor1kx tick timer unit
 

--- a/rtl/verilog/mor1kx_true_dpram_sclk.v
+++ b/rtl/verilog/mor1kx_true_dpram_sclk.v
@@ -1,12 +1,16 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
 
- Description: True dual port ram with dual clock's
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
- Copyright (C) 2013 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
+  Description: True dual port ram with dual clock's
+
+  Copyright (C) 2013 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
 
  ******************************************************************************/
 

--- a/rtl/verilog/mor1kx_true_dpram_sclk.v
+++ b/rtl/verilog/mor1kx_true_dpram_sclk.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: True dual port ram with dual clock's
 

--- a/rtl/verilog/mor1kx_utils.vh
+++ b/rtl/verilog/mor1kx_utils.vh
@@ -1,9 +1,14 @@
-/******************************************************************************
- This Source Code Form is subject to the terms of the
- Open Hardware Description License, v. 1.0. If a copy
- of the OHDL was not distributed with this file, You
- can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
- Copyright (C) 2014 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
+/* ****************************************************************************
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
+
+  Copyright (C) 2014 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
 
  ******************************************************************************/
 

--- a/rtl/verilog/mor1kx_utils.vh
+++ b/rtl/verilog/mor1kx_utils.vh
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Copyright (C) 2014 Stefan Kristiansson <stefan.kristiansson@saunalahti.fi>
 

--- a/rtl/verilog/mor1kx_wb_mux_cappuccino.v
+++ b/rtl/verilog/mor1kx_wb_mux_cappuccino.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: RF writeback mux
 

--- a/rtl/verilog/mor1kx_wb_mux_cappuccino.v
+++ b/rtl/verilog/mor1kx_wb_mux_cappuccino.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: RF writeback mux
 

--- a/rtl/verilog/mor1kx_wb_mux_espresso.v
+++ b/rtl/verilog/mor1kx_wb_mux_espresso.v
@@ -1,8 +1,12 @@
 /* ****************************************************************************
-  This Source Code Form is subject to the terms of the
-  Open Hardware Description License, v. 1.0. If a copy
-  of the OHDL was not distributed with this file, You
-  can obtain one at http://juliusbaxter.net/ohdl/ohdl.txt
+  This source describes Open Hardware and is licensed under the CERN-OHLW v2
+
+  You may redistribute and modify this documentation and make products
+  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
+  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
+  for applicable conditions.
 
   Description: RF writeback mux for espresso pipeline
 

--- a/rtl/verilog/mor1kx_wb_mux_espresso.v
+++ b/rtl/verilog/mor1kx_wb_mux_espresso.v
@@ -1,12 +1,5 @@
 /* ****************************************************************************
-  This source describes Open Hardware and is licensed under the CERN-OHLW v2
-
-  You may redistribute and modify this documentation and make products
-  using it under the terms of the CERN-OHL-W v2 (https:/cern.ch/cern-ohl).
-  This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
-  AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-W v2
-  for applicable conditions.
+  SPDX-License-Identifier: CERN-OHL-W-2.0
 
   Description: RF writeback mux for espresso pipeline
 


### PR DESCRIPTION
Here it is folks, as discussed on the mailing list, the switch from my OHDL licence to CERN-OHL-W-2.0.

(This is the second PR replacing the first which was done under the wrong account.)

Mailing list thread: https://lists.librecores.org/pipermail/openrisc/2021-August/003247.html

Full licence text is here: https://ohwr.org/cern_ohl_w_v2.txt

I've omitted the FPU for now because I believe those authors are not on the list and haven't given their approval in writing yet.

One thing I thought maybe is I should include the SPDX identifier in the headers in addition to the README? Let me know if you think I should update the PR to include that in the headers as well.