### PR TITLE
core: Add parameters to the synth job

### DIFF
--- a/mor1kx.core
+++ b/mor1kx.core
@@ -76,6 +76,102 @@ parameters:
     description : Output mor1kx instruction trace to screen
     paramtype   : plusarg
 
+  FEATURE_DATACACHE:
+    datatype   : str
+    description: Enable the mor1kx data cache, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  FEATURE_DMMU:
+    datatype   : str
+    description: Enable the mor1kx data bus mmu, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  FEATURE_INSTRUCTIONCACHE:
+    datatype   : str
+    description: Enable the mor1kx instruction cache, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  FEATURE_IMMU:
+    datatype   : str
+    description: Enable the mor1kx instruction bus mmu, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  FEATURE_FPU:
+    datatype   : str
+    description: Enable the mor1kx floating point unit, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  FEATURE_ROR:
+    datatype   : str
+    description: Enable the mor1kx rotate right instruction, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  FEATURE_EXT:
+    datatype   : str
+    description: Enable the mor1kx sign extend instructions, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_DCACHE_BLOCK_WIDTH:
+    datatype   : int
+    description: Configure mor1kx d-cache block width in bits, controls block size. default 5
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_DCACHE_LIMIT_WIDTH:
+    datatype   : int
+    description: Configure mor1kx d-cache limit in bits. default 32
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_DCACHE_SET_WIDTH:
+    datatype   : int
+    description: Configure mor1kx d-cache set width in bits, controls numbers of sets. default 9
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_DCACHE_WAYS:
+    datatype   : int
+    description: Configure mor1kx d-cache ways, controls number of blocks per set. default 2
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_ICACHE_BLOCK_WIDTH:
+    datatype   : int
+    description: Configure mor1kx i-cache block width in bits, controls block size. default 5
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_ICACHE_LIMIT_WIDTH:
+    datatype   : int
+    description: Configure mor1kx i-cache limit in bits. default 32
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_ICACHE_SET_WIDTH:
+    datatype   : int
+    description: Configure mor1kx i-cache set width in bits, controls numbers of sets. default 9
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_ICACHE_WAYS:
+    datatype   : int
+    description: Configure mor1kx i-cache ways, controls number of blocks per set. default 2
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_RF_NUM_SHADOW_GPR:
+    datatype   : int
+    description: Configure mor1kx available shadow registers. default 0
+    paramtype  : vlogparam
+    scope      : private
+
 targets:
   default:
     filesets:
@@ -93,5 +189,12 @@ targets:
     filesets : [core , fpu]
     tools:
       icestorm:
+        arch: xilinx
         pnr: none
     toplevel : mor1kx
+    parameters: [FEATURE_DATACACHE, FEATURE_DMMU,
+                 FEATURE_INSTRUCTIONCACHE, FEATURE_IMMU,
+                 FEATURE_FPU, FEATURE_ROR, FEATURE_EXT,
+                 OPTION_DCACHE_BLOCK_WIDTH, OPTION_DCACHE_LIMIT_WIDTH, OPTION_DCACHE_SET_WIDTH, OPTION_DCACHE_WAYS,
+                 OPTION_ICACHE_BLOCK_WIDTH, OPTION_ICACHE_LIMIT_WIDTH, OPTION_ICACHE_SET_WIDTH, OPTION_ICACHE_WAYS,
+                 OPTION_RF_NUM_SHADOW_GPR]


### PR DESCRIPTION
THis allows us to run the synthesis with different configurations.  For
example:

```
    fusesoc run --target synth mor1kx \
      --FEATURE_DATACACHE ENABLED \
      --FEATURE_DMMU ENABLED \
      --OPTION_DCACHE_BLOCK_WIDTH 4 \
      --OPTION_DCACHE_LIMIT_WIDTH 31 \
      --OPTION_DCACHE_SET_WIDTH 8 \
      --OPTION_DCACHE_WAYS 1 \
      --FEATURE_INSTRUCTIONCACHE ENABLED \
      --FEATURE_IMMU ENABLED \
      --OPTION_ICACHE_BLOCK_WIDTH 4 \
      --OPTION_ICACHE_LIMIT_WIDTH 31 \
      --OPTION_ICACHE_SET_WIDTH 8 \
      --OPTION_ICACHE_WAYS 1 \
      --OPTION_RF_NUM_SHADOW_GPR 1 \
      --FEATURE_ROR ENABLED \
      --FEATURE_EXT ENABLED \
      --FEATURE_FPU ENABLED > yosys.log ; grep -A10 'Number of cells' yosys.log

    INFO: Preparing ::mor1kx:5.0-r3
    INFO: Setting up project
    INFO: Setting up project
    INFO: Building
    INFO: Running
       Number of cells:              32484
	 SB_CARRY                      849
	 SB_DFF                        446
	 SB_DFFE                      9848
	 SB_DFFESR                     676
	 SB_DFFESS                      16
	 SB_DFFSR                       76
	 SB_DFFSS                        3
	 SB_LUT4                     20537
	 SB_RAM40_4K                    33
```