### PR TITLE
fix to unbreak verilator compatability

### DIFF
--- a/rtl/verilog/mor1kx_cpu.v
+++ b/rtl/verilog/mor1kx_cpu.v
@@ -198,13 +198,11 @@ module mor1kx_cpu
 	// synthesis translate_off
 `ifndef SYNTHESIS
    /* Provide interface hooks for register functions. */
+	`include "mor1kx_utils.vh"
+	localparam RF_ADDR_WIDTH = calc_rf_addr_width(OPTION_RF_ADDR_WIDTH,
+                                                  OPTION_RF_NUM_SHADOW_GPR);
    generate
       if (OPTION_CPU=="CAPPUCCINO") begin : monitor
-
-`include "mor1kx_utils.vh"
-         localparam RF_ADDR_WIDTH = calc_rf_addr_width(OPTION_RF_ADDR_WIDTH,
-                                                       OPTION_RF_NUM_SHADOW_GPR);
-
          function [OPTION_OPERAND_WIDTH-1:0] get_gpr;
             // verilator public
             input [RF_ADDR_WIDTH-1:0] gpr_num;


### PR DESCRIPTION
move include / local parameter calculation to fix verilator compilation issue

error:
```
%Error: /home/hhe07/Documents/openrisc/litex/pythondata-cpu-mor1kx/pythondata_cpu_mor1kx/verilog/rtl/verilog/mor1kx_utils.vh:96:18: Constant function may not be declared under generate (IEEE 1800-2023 13.4.3)
                                                                                                                                  : ... note: In instance 'sim.mor1kx.mor1kx_cpu'
   96 | function integer calc_rf_addr_width;
      |                  ^~~~~~~~~~~~~~~~~~
        /home/hhe07/Documents/openrisc/litex/pythondata-cpu-mor1kx/pythondata_cpu_mor1kx/verilog/rtl/verilog/mor1kx_cpu.v:205:1: ... note: In file included from 'mor1kx_cpu.v'
%Error: /home/hhe07/Documents/openrisc/litex/pythondata-cpu-mor1kx/pythondata_cpu_mor1kx/verilog/rtl/verilog/mor1kx_cpu.v:205:37: Expecting expression to be constant, but can't determine constant for FUNCREF 'calc_rf_addr_width'
                                                                                                                                : ... note: In instance 'sim.mor1kx.mor1kx_cpu'
        /home/hhe07/Documents/openrisc/litex/pythondata-cpu-mor1kx/pythondata_cpu_mor1kx/verilog/rtl/verilog/mor1kx_utils.vh:96:18: ... Location of non-constant FUNC 'calc_rf_addr_width': Constant function called under generate
        /home/hhe07/Documents/openrisc/litex/pythondata-cpu-mor1kx/pythondata_cpu_mor1kx/verilog/rtl/verilog/mor1kx_cpu.v:205:37: ... Called from 'calc_rf_addr_width()' with parameters:
           rf_addr_width = ?32?h5
           rf_num_shadow_gpr = ?32?h0
  205 |          localparam RF_ADDR_WIDTH = calc_rf_addr_width(OPTION_RF_ADDR_WIDTH,
      |                                     ^~~~~~~~~~~~~~~~~~
%Error: Exiting due to 2 error(s)
````