### PR TITLE
Formal verification for pfpu32_cmp

### DIFF
--- a/bench/formal/Makefile
+++ b/bench/formal/Makefile
@@ -27,14 +27,16 @@ TESTS := mor1kx_cache_lru \
 	mor1kx_ctrl_cappuccino \
 	mor1kx_rf_cappuccino \
 	mor1kx_bus_if_wb32 \
-	pfpu32_addsub
+	pfpu32_addsub \
+	pfpu32_cmp
 
 # tests that no longer work keep them here so we can easily
 # run them if we want to try and fix them.
 BROKEN_TESTS := \
 	mor1kx_lsu_cappuccino \
 	mor1kx_cpu_cappuccino \
-	mor1kx
+	mor1kx \
+	pfpu32_cmp_snan_bug
 
 all: $(TESTS)
 clean:

--- a/bench/formal/pfpu32_cmp.sby
+++ b/bench/formal/pfpu32_cmp.sby
@@ -1,0 +1,17 @@
+[options]
+mode prove
+depth 8
+
+[engines]
+smtbmc yices
+
+[script]
+read -formal -D PFPU32_FCMP pfpu32_cmp.v
+
+
+prep -top pfpu32_fcmp
+
+[files]
+../../rtl/verilog/pfpu32/pfpu32_cmp.v
+../../rtl/verilog/mor1kx-defines.v
+../../rtl/verilog/mor1kx-sprs.v

--- a/bench/formal/pfpu32_cmp_snan_bug.sby
+++ b/bench/formal/pfpu32_cmp_snan_bug.sby
@@ -1,0 +1,17 @@
+[options]
+mode prove
+depth 8
+
+[engines]
+smtbmc yices
+
+[script]
+read -formal -D PFPU32_FCMP -D PFPU32_FCMP_SNAN_BUG pfpu32_cmp.v
+
+
+prep -top pfpu32_fcmp
+
+[files]
+../../rtl/verilog/pfpu32/pfpu32_cmp.v
+../../rtl/verilog/mor1kx-defines.v
+../../rtl/verilog/mor1kx-sprs.v


### PR DESCRIPTION
This adds formal verification for the comparison unit in the FPU. Comparison operations don't appear to be fully specified in the ISA spec, but I took my best stab at sensible semantics, based on my understanding of IEEE 754.

For the most part, what I came up with lines up with the implementation. The only difference is the behaviour of `sfult`, `sfule`, `sfugt`, and `sfuge` when given a signalling NaN. I believe these should result in an exception (signalled by `inv_o`), but the implementation doesn't do this.

To get tests to pass, the assertions introduced here have an exception carved out for this behavioural difference. This exception is disabled in the `pfpu32_cmp_snan_bug` test, which currently fails.